### PR TITLE
fix: remove literal newline escapes in container diagram

### DIFF
--- a/diagrams/container.mmd
+++ b/diagrams/container.mmd
@@ -4,10 +4,10 @@ flowchart TB
     end
 
     subgraph runtime["Local Container Runtime (docker compose)"]
-        web[web\nFrontend]
-        api[api\nBackend HTTP API]
-        idp[idp\nAuthentication Provider]
-        db[(db\nRelational Database)]
+        web[web - Frontend]
+        api[api - Backend HTTP API]
+        idp[idp - Authentication Provider]
+        db[(db - Relational Database)]
     end
 
     browser -->|HTTPS| web


### PR DESCRIPTION
## Summary
- replace Mermaid node labels that used literal \\n escapes in diagrams/container.mmd
- use single-line labels to ensure consistent rendering in GitHub

## Result
The container diagram no longer shows \\n in rendered text.

fixes #2