### PR TITLE
feat: add docker compose runtime for local stack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.dotnet
+bin
+obj
+**/bin
+**/obj
+README.md
+docs
+diagrams
+*.log

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See `docs/scope-and-assumptions.md` for details.
 ### Prerequisites
 
 - .NET SDK 10
-- Docker Desktop for later container/runtime work
+- Docker Desktop
 
 ### Run locally
 
@@ -60,6 +60,23 @@ You can also build the current solution with:
 dotnet build BlijvenLeren.sln
 ```
 
+### Run the container runtime
+
+```bash
+docker compose up --build
+```
+
+Container ports:
+- app: `http://localhost:8080`
+- db: `localhost:5432`
+- idp: `http://localhost:8081`
+
+Useful endpoints after startup:
+- app landing page: `http://localhost:8080/`
+- app health: `http://localhost:8080/api/health`
+- dependency probe: `http://localhost:8080/api/health/dependencies`
+- Keycloak admin console: `http://localhost:8081/` with `admin` / `admin`
+
 ## Current bootstrap scope
 
 Issue `#4` establishes a runnable starting point rather than full feature coverage. The current implementation:
@@ -67,6 +84,18 @@ Issue `#4` establishes a runnable starting point rather than full feature covera
 - provides a placeholder landing page for the browser experience
 - exposes a placeholder health endpoint for API connectivity checks
 - intentionally leaves domain logic, persistence, authentication and containers for follow-up issues
+
+Issue `#5` adds the first container runtime around that bootstrap:
+- `app` hosts both the browser UI and the API surface
+- `db` provides a PostgreSQL instance for later persistence work
+- `idp` provides a local Keycloak instance for later authentication work
+- the application exposes a dependency probe so container-network reachability is visible during review
+
+### Container troubleshooting
+
+- If `docker compose up --build` fails on image pulls, retry after Docker Desktop finishes starting and registry access is available.
+- If port `8080`, `8081`, or `5432` is already in use, stop the conflicting service or change the port mapping in `compose.yaml`.
+- If the app starts before `db` or `idp` is fully ready, refresh `http://localhost:8080/api/health/dependencies` after a few seconds. Full healthchecks are deferred follow-up work.
 
 ## Why Terraform is not included in this MVP
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,43 @@
+name: blijvenleren-mvp
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: src/BlijvenLeren.App/Dockerfile
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_URLS: http://+:8080
+      Runtime__Database__Host: db
+      Runtime__Database__Port: 5432
+      Runtime__IdentityProvider__Authority: http://idp:8080
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+      - idp
+
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: blijvenleren
+      POSTGRES_USER: blijvenleren
+      POSTGRES_PASSWORD: blijvenleren
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  idp:
+    image: quay.io/keycloak/keycloak:26.1.4
+    command:
+      - start-dev
+      - --http-port=8080
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+    ports:
+      - "8081:8080"
+
+volumes:
+  postgres-data:

--- a/diagrams/container.mmd
+++ b/diagrams/container.mmd
@@ -4,14 +4,11 @@ flowchart TB
     end
 
     subgraph runtime["Local Container Runtime (docker compose)"]
-        web[web - Frontend]
-        api[api - Backend HTTP API]
+        app[app - Browser UI + HTTP API]
         idp[idp - Authentication Provider]
         db[(db - Relational Database)]
     end
 
-    browser -->|HTTPS| web
-    web -->|HTTP API calls| api
-    web -->|Login / callback| idp
-    api -->|Token validation / user info| idp
-    api -->|SQL| db
+    browser -->|HTTP :8080| app
+    app -->|Token validation / user info| idp
+    app -->|SQL| db

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,6 +22,21 @@ The solution is designed as a locally runnable MVP with the following building b
 - `db`: persistent relational database
 - `idp`: authentication and identity management
 
+## Local container runtime
+
+`compose.yaml` defines the current local runtime with these services:
+
+- `app`: built from `src/BlijvenLeren.App/Dockerfile`, exposed on host port `8080`
+- `db`: PostgreSQL 16, exposed on host port `5432`
+- `idp`: Keycloak in development mode, exposed on host port `8081`
+
+Current runtime behavior:
+- browser traffic goes to `app`
+- browser and future client-side API calls terminate in the same `app` service
+- `app` can reach `db` through the compose network name `db`
+- `app` can reach `idp` through the compose network name `idp`
+- `app` exposes `/api/health/dependencies` to show whether those dependencies are reachable from inside the runtime
+
 ## Current project structure
 
 The runnable application code currently lives in:
@@ -69,6 +84,18 @@ Impact:
 - Reviewers can run one process to see both surfaces.
 - A later split remains possible if the application grows or deployment concerns become stricter.
 - Architecture documentation must explicitly record that this is an MVP simplification rather than a final scaling choice.
+
+## Compose scope trade-off
+
+The original container runtime issue described separate `web` and `api` services. The implemented compose runtime keeps a single `app` service instead.
+
+Reasoning:
+- The current application is still a combined ASP.NET Core app.
+- Splitting the container topology before the code splits would add operational structure that the application does not yet need.
+
+Impact:
+- The compose runtime matches the implementation rather than the earlier aspirational architecture wording.
+- Future issues can introduce a separate `web` and `api` runtime if the application is intentionally split later.
 
 ## Diagrams
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -6,3 +6,9 @@
 - Add a shared contracts project if DTO reuse starts to create coupling or duplication.
 - Add coding standards enforcement such as `.editorconfig` and CI validation once the codebase has more than the initial bootstrap slice.
 - Add automated tests as part of issue `#12`, which already tracks the MVP test suite.
+
+## Deferred from issue #5
+
+- Add Docker Compose profiles for a faster inner-loop setup once more services exist.
+- Add explicit healthchecks and readiness ordering for all services instead of relying on startup timing.
+- Replace the Keycloak development-mode defaults with stronger local configuration once the authentication flow is implemented.

--- a/docs/technical-decisions.md
+++ b/docs/technical-decisions.md
@@ -118,3 +118,21 @@ Issue `#4` needs a runnable skeleton, but a separate web and API project split a
 
 **Rejected alternatives**
 - Start with separate web and API projects immediately: rejected because it adds structure before there is enough behavior to justify it in this MVP.
+
+---
+
+## TD-010 Use Docker Compose with app, db and idp services for local runtime
+**Decision**
+Use `compose.yaml` to run the MVP locally with three services: `app`, `db`, and `idp`.
+
+**Why**
+The repository needs a single-command runtime that reflects the documented container architecture, but the current codebase only has one combined ASP.NET Core application rather than separate web and API deployables.
+
+**Impact**
+- Local reviewers can start the runtime with one Docker Compose command.
+- The runtime includes the infrastructure services needed for upcoming persistence and authentication work.
+- The compose topology intentionally differs from the older `web`/`api` wording and must stay documented as an MVP simplification.
+
+**Rejected alternatives**
+- Force separate `web` and `api` containers immediately: rejected because the codebase still ships one application artifact.
+- Delay container runtime work until persistence and authentication are implemented: rejected because local reproducibility is a stated architecture goal.

--- a/src/BlijvenLeren.App/Configuration/RuntimeOptions.cs
+++ b/src/BlijvenLeren.App/Configuration/RuntimeOptions.cs
@@ -1,0 +1,22 @@
+namespace BlijvenLeren.App.Configuration;
+
+public sealed class RuntimeOptions
+{
+    public const string SectionName = "Runtime";
+
+    public DatabaseOptions Database { get; init; } = new();
+
+    public IdentityProviderOptions IdentityProvider { get; init; } = new();
+}
+
+public sealed class DatabaseOptions
+{
+    public string Host { get; init; } = "localhost";
+
+    public int Port { get; init; } = 5432;
+}
+
+public sealed class IdentityProviderOptions
+{
+    public string Authority { get; init; } = "http://localhost:8081";
+}

--- a/src/BlijvenLeren.App/Dockerfile
+++ b/src/BlijvenLeren.App/Dockerfile
@@ -1,0 +1,19 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+COPY BlijvenLeren.sln ./
+COPY src/BlijvenLeren.App/BlijvenLeren.App.csproj src/BlijvenLeren.App/
+RUN dotnet restore BlijvenLeren.sln
+
+COPY src/BlijvenLeren.App/. ./src/BlijvenLeren.App/
+RUN dotnet publish src/BlijvenLeren.App/BlijvenLeren.App.csproj -c Release -o /app/publish /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
+WORKDIR /app
+
+COPY --from=build /app/publish .
+
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "BlijvenLeren.App.dll"]

--- a/src/BlijvenLeren.App/Pages/Index.cshtml
+++ b/src/BlijvenLeren.App/Pages/Index.cshtml
@@ -14,3 +14,17 @@
         <code>/api/health</code> so later vertical slices can build on a runnable foundation.
     </p>
 </section>
+
+<section class="pb-4">
+    <h2 class="h4">Container runtime</h2>
+    <p>
+        Issue <code>#5</code> adds a Docker Compose runtime with one application container plus local database and
+        identity-provider services.
+    </p>
+    <ul>
+        <li>Application: <code>@Model.AppBaseUrl</code></li>
+        <li>Database host: <code>@Model.DatabaseHost:@Model.DatabasePort</code></li>
+        <li>Identity provider: <code>@Model.IdentityProviderAuthority</code></li>
+        <li>Dependency probe: <code>@Model.AppBaseUrl/api/health/dependencies</code></li>
+    </ul>
+</section>

--- a/src/BlijvenLeren.App/Pages/Index.cshtml.cs
+++ b/src/BlijvenLeren.App/Pages/Index.cshtml.cs
@@ -1,12 +1,27 @@
-using Microsoft.AspNetCore.Mvc;
+using BlijvenLeren.App.Configuration;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Options;
 
 namespace BlijvenLeren.App.Pages;
 
 public class IndexModel : PageModel
 {
+    private readonly RuntimeOptions _runtimeOptions;
+
+    public IndexModel(IOptions<RuntimeOptions> runtimeOptions)
+    {
+        _runtimeOptions = runtimeOptions.Value;
+    }
+
+    public string AppBaseUrl => $"{Request.Scheme}://{Request.Host}";
+
+    public string DatabaseHost => _runtimeOptions.Database.Host;
+
+    public int DatabasePort => _runtimeOptions.Database.Port;
+
+    public string IdentityProviderAuthority => _runtimeOptions.IdentityProvider.Authority;
+
     public void OnGet()
     {
-
     }
 }

--- a/src/BlijvenLeren.App/Program.cs
+++ b/src/BlijvenLeren.App/Program.cs
@@ -1,9 +1,16 @@
+using System.Net.Sockets;
+using BlijvenLeren.App.Configuration;
+using Microsoft.Extensions.Options;
+
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Logging.ClearProviders();
 builder.Logging.AddConsole();
 
+builder.Services.Configure<RuntimeOptions>(
+    builder.Configuration.GetSection(RuntimeOptions.SectionName));
 builder.Services.AddRazorPages();
+builder.Services.AddHttpClient();
 
 var app = builder.Build();
 
@@ -29,8 +36,85 @@ app.MapGet("/api/health", () => Results.Ok(new
     mode = "bootstrap"
 }));
 
+app.MapGet(
+    "/api/health/dependencies",
+    async (
+        IOptions<RuntimeOptions> runtimeOptions,
+        IHttpClientFactory httpClientFactory,
+        CancellationToken cancellationToken) =>
+    {
+        var runtime = runtimeOptions.Value;
+
+        var database = await CheckTcpDependencyAsync(
+            runtime.Database.Host,
+            runtime.Database.Port,
+            cancellationToken);
+
+        var identityProvider = await CheckHttpDependencyAsync(
+            runtime.IdentityProvider.Authority,
+            httpClientFactory,
+            cancellationToken);
+
+        return Results.Ok(new
+        {
+            status = database.healthy && identityProvider.healthy ? "ok" : "degraded",
+            dependencies = new
+            {
+                database,
+                identityProvider
+            }
+        });
+    });
+
 app.MapStaticAssets();
 app.MapRazorPages()
    .WithStaticAssets();
 
 app.Run();
+
+static async Task<DependencyCheckResult> CheckTcpDependencyAsync(
+    string host,
+    int port,
+    CancellationToken cancellationToken)
+{
+    using var client = new TcpClient();
+    using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+    timeout.CancelAfter(TimeSpan.FromSeconds(3));
+
+    try
+    {
+        await client.ConnectAsync(host, port, timeout.Token);
+        return new DependencyCheckResult(host, port, null, true, null, null);
+    }
+    catch (Exception ex)
+    {
+        return new DependencyCheckResult(host, port, null, false, null, ex.Message);
+    }
+}
+
+static async Task<DependencyCheckResult> CheckHttpDependencyAsync(
+    string authority,
+    IHttpClientFactory httpClientFactory,
+    CancellationToken cancellationToken)
+{
+    var client = httpClientFactory.CreateClient();
+    client.Timeout = TimeSpan.FromSeconds(3);
+
+    try
+    {
+        using var response = await client.GetAsync(authority, cancellationToken);
+        return new DependencyCheckResult(null, null, authority, response.IsSuccessStatusCode, (int)response.StatusCode, null);
+    }
+    catch (Exception ex)
+    {
+        return new DependencyCheckResult(null, null, authority, false, null, ex.Message);
+    }
+}
+
+internal sealed record DependencyCheckResult(
+    string? Host,
+    int? Port,
+    string? Authority,
+    bool healthy,
+    int? StatusCode,
+    string? Error);

--- a/src/BlijvenLeren.App/appsettings.json
+++ b/src/BlijvenLeren.App/appsettings.json
@@ -5,5 +5,14 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "Runtime": {
+    "Database": {
+      "Host": "localhost",
+      "Port": 5432
+    },
+    "IdentityProvider": {
+      "Authority": "http://localhost:8081"
+    }
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## Summary
- add a Docker Compose runtime with a single pp service plus PostgreSQL and Keycloak
- add a multi-stage Dockerfile and runtime configuration so the app can resolve container-network dependencies
- update docs and the container diagram to record the clarified single-container decision for the application runtime

## Issue
Fixes #5

## Notes
- Runtime design follows the clarification in issue comments: one application container is sufficient for now, with PostgreSQL and Keycloak as pragmatic local defaults.
- The dependency probe endpoint /api/health/dependencies exists to make app-to-db and app-to-idp reachability visible during review.

## Verification
- dotnet build BlijvenLeren.sln -c Release
- docker compose config
- local smoke check against GET /api/health and GET /api/health/dependencies
- docker compose up --build -d could not be completed in this environment because the Docker daemon was unavailable (//./pipe/dockerDesktopLinuxEngine not found)