### PR TITLE
feat: add seeded demo data workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Useful endpoints after startup:
 - app health: `http://localhost:8080/api/health`
 - dependency probe: `http://localhost:8080/api/health/dependencies`
 - persistence smoke path: `POST http://localhost:8080/api/health/persistence-smoke`
+- demo data reseed path: `POST http://localhost:8080/api/demo/seed-data?reset=true`
 - Keycloak admin console: `http://localhost:8081/` with `admin` / `admin`
 
 ## Current bootstrap scope
@@ -98,6 +99,12 @@ Issue `#6` adds the first persistence slice:
 - an initial migration under `src/BlijvenLeren.App/Data/Migrations`
 - a persistence smoke endpoint that writes and reads temporary data inside a transaction
 
+Issue `#18` adds predictable demo data:
+- three learning resources with review-friendly titles and descriptions
+- internal comments that are immediately visible
+- external comments in `Pending` and `Rejected` moderation states
+- a reseed endpoint for resetting the local walkthrough data
+
 ### Database migration workflow
 
 Restore the local EF tool:
@@ -114,6 +121,23 @@ dotnet ef database update --configuration Release --project src/BlijvenLeren.App
 
 Compose note:
 - `compose.yaml` sets `Runtime__Database__ApplyMigrationsOnStartup=true` for the `app` service, so the container runtime applies pending migrations automatically against the local PostgreSQL instance.
+- `compose.yaml` also sets `Runtime__Database__SeedDemoDataOnStartup=true`, so a clean local container runtime starts with representative review data.
+
+### Demo data workflow
+
+The container runtime seeds demo data automatically when the database is empty.
+
+To reset demo data manually:
+
+```bash
+curl -X POST "http://localhost:8080/api/demo/seed-data?reset=true"
+```
+
+Expected seeded shape:
+- 3 learning resources
+- internal comments in `Approved`
+- external comments in `Pending`
+- external comments in `Rejected`
 
 ### Container troubleshooting
 
@@ -121,6 +145,7 @@ Compose note:
 - If port `8080`, `8081`, or `5432` is already in use, stop the conflicting service or change the port mapping in `compose.yaml`.
 - If the app starts before `db` or `idp` is fully ready, refresh `http://localhost:8080/api/health/dependencies` after a few seconds. Full healthchecks are deferred follow-up work.
 - If you are running the app outside Docker and do not want startup migrations, leave `Runtime__Database__ApplyMigrationsOnStartup` unset or `false`.
+- If you are running the app outside Docker and want startup seeding, set `Runtime__Database__SeedDemoDataOnStartup=true`.
 
 ## Why Terraform is not included in this MVP
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,6 +10,7 @@ services:
       ASPNETCORE_URLS: http://+:8080
       ConnectionStrings__BlijvenLeren: Host=db;Port=5432;Database=blijvenleren;Username=blijvenleren;Password=blijvenleren
       Runtime__Database__ApplyMigrationsOnStartup: true
+      Runtime__Database__SeedDemoDataOnStartup: true
       Runtime__Database__Host: db
       Runtime__Database__Port: 5432
       Runtime__IdentityProvider__Authority: http://idp:8080

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,6 +37,7 @@ Current runtime behavior:
 - `app` can reach `idp` through the compose network name `idp`
 - `app` exposes `/api/health/dependencies` to show whether those dependencies are reachable from inside the runtime
 - `app` applies pending EF Core migrations automatically in the compose runtime before serving requests
+- `app` seeds demo data automatically in the compose runtime when the database is empty
 
 ## Current project structure
 
@@ -66,6 +67,21 @@ Schema notes:
 - comment moderation is stored explicitly as `Pending`, `Approved`, or `Rejected`
 - comment author type is stored explicitly as `Internal` or `External`
 - the first index targets `(LearningResourceId, Status)` to support resource detail and moderation queries
+
+## Demo data
+
+The current demo-data approach lives inside the application runtime:
+
+- `DemoDataSeeder` inserts a small representative dataset through the same DbContext used by the app
+- startup seeding is opt-in through configuration
+- the compose runtime enables startup seeding for local review convenience
+- `POST /api/demo/seed-data?reset=true` clears existing records and reloads the demo dataset
+
+The seeded data intentionally demonstrates:
+- multiple learning resources
+- internal comments that are already approved
+- external comments awaiting moderation
+- external comments that were rejected
 
 ## Design goals
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -18,3 +18,9 @@
 - Add seed data for a richer local demo once the CRUD flow exists.
 - Add more targeted indexes after the real list and moderation query patterns are implemented.
 - Split the persistence smoke path into automated integration tests once issue `#12` is implemented.
+
+## Deferred from issue #18
+
+- Add environment-specific seed sets once reviewer and developer workflows diverge.
+- Add richer personas, more comments per resource, and moderation-history examples once the UI can surface them.
+- Replace the HTTP reseed endpoint with a more role-aware or operator-only flow once authentication and authorization are implemented.

--- a/docs/technical-decisions.md
+++ b/docs/technical-decisions.md
@@ -154,3 +154,21 @@ Issue `#6` needs a reviewable relational schema plus a repeatable migration work
 **Rejected alternatives**
 - Hand-write raw SQL migrations only: rejected because it adds manual mapping overhead at this stage without improving reviewer clarity.
 - Delay ORM selection until CRUD features are implemented: rejected because the current issue explicitly requires a schema and migration workflow now.
+
+---
+
+## TD-012 Seed demo data through the application data layer
+**Decision**
+Seed review data through the application itself, using the existing DbContext and an opt-in runtime flag.
+
+**Why**
+Issue `#18` asks for predictable demo data aligned with the MVP runtime. Reusing the application data layer keeps the seeding path visible, easy to review, and consistent with the current single-app architecture.
+
+**Impact**
+- A clean compose runtime can start with representative review data automatically.
+- Demo data can be reset through a simple HTTP endpoint instead of an extra external script.
+- Seed logic stays close to the entity model and evolves with schema changes.
+
+**Rejected alternatives**
+- Maintain separate SQL seed scripts only: rejected because it duplicates model knowledge outside the app.
+- Seed unconditionally on every startup: rejected because it would overwrite manual demo changes too aggressively.

--- a/src/BlijvenLeren.App/Configuration/RuntimeOptions.cs
+++ b/src/BlijvenLeren.App/Configuration/RuntimeOptions.cs
@@ -13,6 +13,8 @@ public sealed class DatabaseOptions
 {
     public bool ApplyMigrationsOnStartup { get; init; }
 
+    public bool SeedDemoDataOnStartup { get; init; }
+
     public string Host { get; init; } = "localhost";
 
     public int Port { get; init; } = 5432;

--- a/src/BlijvenLeren.App/Data/DemoDataSeeder.cs
+++ b/src/BlijvenLeren.App/Data/DemoDataSeeder.cs
@@ -1,0 +1,146 @@
+using BlijvenLeren.App.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace BlijvenLeren.App.Data;
+
+public sealed class DemoDataSeeder(AppDbContext dbContext)
+{
+    public async Task<SeedResult> SeedAsync(bool resetExistingData, CancellationToken cancellationToken)
+    {
+        if (resetExistingData)
+        {
+            dbContext.Comments.RemoveRange(dbContext.Comments);
+            dbContext.LearningResources.RemoveRange(dbContext.LearningResources);
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+        else if (await dbContext.LearningResources.AnyAsync(cancellationToken))
+        {
+            return await BuildResultAsync("unchanged", cancellationToken);
+        }
+
+        var seededResources = BuildSeedResources();
+        dbContext.LearningResources.AddRange(seededResources);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return await BuildResultAsync(resetExistingData ? "reseeded" : "seeded", cancellationToken);
+    }
+
+    private async Task<SeedResult> BuildResultAsync(string status, CancellationToken cancellationToken)
+    {
+        var resourceCount = await dbContext.LearningResources.CountAsync(cancellationToken);
+        var commentCount = await dbContext.Comments.CountAsync(cancellationToken);
+
+        var statusCounts = await dbContext.Comments
+            .GroupBy(comment => comment.Status)
+            .Select(group => new CommentStatusCount(group.Key.ToString(), group.Count()))
+            .ToListAsync(cancellationToken);
+
+        return new SeedResult(status, resourceCount, commentCount, statusCounts);
+    }
+
+    private static IReadOnlyList<LearningResource> BuildSeedResources()
+    {
+        return
+        [
+            new LearningResource
+            {
+                Id = Guid.Parse("22f5008e-e4c0-4494-92e1-e2c5b4f76c91"),
+                Title = "Intro to Azure Fundamentals",
+                Description = "Starter material for colleagues who need a fast cloud platform overview.",
+                Url = "https://learn.microsoft.com/training/paths/microsoft-azure-fundamentals-describe-cloud-concepts/",
+                CreatedUtc = DateTimeOffset.Parse("2026-03-01T09:00:00Z"),
+                Comments =
+                [
+                    new Comment
+                    {
+                        Id = Guid.Parse("6226c6d0-84af-4cca-8d70-a2501002ab7b"),
+                        AuthorDisplayName = "Platform Coach",
+                        AuthorType = CommentAuthorType.Internal,
+                        Body = "Good first stop for new teammates before deeper platform tracks.",
+                        Status = CommentStatus.Approved,
+                        CreatedUtc = DateTimeOffset.Parse("2026-03-02T08:30:00Z"),
+                        ModeratedUtc = DateTimeOffset.Parse("2026-03-02T08:30:00Z")
+                    },
+                    new Comment
+                    {
+                        Id = Guid.Parse("858147fc-37c2-4d69-a85d-c9fdab5d46aa"),
+                        AuthorDisplayName = "External Guest",
+                        AuthorType = CommentAuthorType.External,
+                        Body = "Could use a note about which modules are most relevant for non-engineers.",
+                        Status = CommentStatus.Pending,
+                        CreatedUtc = DateTimeOffset.Parse("2026-03-03T14:15:00Z")
+                    }
+                ]
+            },
+            new LearningResource
+            {
+                Id = Guid.Parse("74f2ef58-f5fb-4760-ae9d-95c82c6e0a6f"),
+                Title = "Secure Coding in .NET",
+                Description = "Practical reference material for common ASP.NET Core security pitfalls and mitigations.",
+                Url = "https://learn.microsoft.com/aspnet/core/security/",
+                CreatedUtc = DateTimeOffset.Parse("2026-03-01T10:00:00Z"),
+                Comments =
+                [
+                    new Comment
+                    {
+                        Id = Guid.Parse("a11f6c9f-2e98-43a0-95da-70bd767f73c9"),
+                        AuthorDisplayName = "Security Reviewer",
+                        AuthorType = CommentAuthorType.Internal,
+                        Body = "Keep this visible in the demo because it connects well to the documented security shortcuts.",
+                        Status = CommentStatus.Approved,
+                        CreatedUtc = DateTimeOffset.Parse("2026-03-02T10:45:00Z"),
+                        ModeratedUtc = DateTimeOffset.Parse("2026-03-02T10:45:00Z")
+                    },
+                    new Comment
+                    {
+                        Id = Guid.Parse("86c8cdab-0c38-4b97-bc47-9bafcf046ea7"),
+                        AuthorDisplayName = "Community Contributor",
+                        AuthorType = CommentAuthorType.External,
+                        Body = "I submitted a related OWASP resource, but this one is probably enough for the MVP.",
+                        Status = CommentStatus.Rejected,
+                        CreatedUtc = DateTimeOffset.Parse("2026-03-04T11:20:00Z"),
+                        ModeratedUtc = DateTimeOffset.Parse("2026-03-05T09:00:00Z")
+                    }
+                ]
+            },
+            new LearningResource
+            {
+                Id = Guid.Parse("fb8fb6b5-ccf8-4e48-abfe-0ea184d37b90"),
+                Title = "Effective Feedback for Peer Reviews",
+                Description = "Short training material focused on giving actionable code-review feedback.",
+                Url = "https://google.github.io/eng-practices/review/reviewer/",
+                CreatedUtc = DateTimeOffset.Parse("2026-03-01T11:00:00Z"),
+                Comments =
+                [
+                    new Comment
+                    {
+                        Id = Guid.Parse("d2060ff2-f743-4f34-a3c9-c8f69bceffb0"),
+                        AuthorDisplayName = "Team Lead",
+                        AuthorType = CommentAuthorType.Internal,
+                        Body = "Useful reference for the reviewability goals in this assignment repo.",
+                        Status = CommentStatus.Approved,
+                        CreatedUtc = DateTimeOffset.Parse("2026-03-02T12:10:00Z"),
+                        ModeratedUtc = DateTimeOffset.Parse("2026-03-02T12:10:00Z")
+                    },
+                    new Comment
+                    {
+                        Id = Guid.Parse("71f04c2c-8af7-42cf-9778-6b4ee2559f5b"),
+                        AuthorDisplayName = "External Reviewer",
+                        AuthorType = CommentAuthorType.External,
+                        Body = "Would be nice to add one Dutch-language review article later.",
+                        Status = CommentStatus.Pending,
+                        CreatedUtc = DateTimeOffset.Parse("2026-03-06T07:50:00Z")
+                    }
+                ]
+            }
+        ];
+    }
+}
+
+public sealed record SeedResult(
+    string Status,
+    int ResourceCount,
+    int CommentCount,
+    IReadOnlyList<CommentStatusCount> CommentStatusCounts);
+
+public sealed record CommentStatusCount(string Status, int Count);

--- a/src/BlijvenLeren.App/Program.cs
+++ b/src/BlijvenLeren.App/Program.cs
@@ -14,12 +14,14 @@ builder.Services.Configure<RuntimeOptions>(
     builder.Configuration.GetSection(RuntimeOptions.SectionName));
 builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("BlijvenLeren")));
+builder.Services.AddScoped<DemoDataSeeder>();
 builder.Services.AddRazorPages();
 builder.Services.AddHttpClient();
 
 var app = builder.Build();
 
 await ApplyDatabaseMigrationsAsync(app);
+await SeedDemoDataAsync(app);
 
 if (!app.Environment.IsDevelopment())
 {
@@ -117,6 +119,14 @@ app.MapPost(
         });
     });
 
+app.MapPost(
+    "/api/demo/seed-data",
+    async (bool? reset, DemoDataSeeder seeder, CancellationToken cancellationToken) =>
+    {
+        var result = await seeder.SeedAsync(reset ?? false, cancellationToken);
+        return Results.Ok(result);
+    });
+
 app.MapStaticAssets();
 app.MapRazorPages()
    .WithStaticAssets();
@@ -191,4 +201,25 @@ static async Task ApplyDatabaseMigrationsAsync(WebApplication app)
     }
 
     await dbContext.Database.MigrateAsync();
+}
+
+static async Task SeedDemoDataAsync(WebApplication app)
+{
+    using var scope = app.Services.CreateScope();
+    var runtimeOptions = scope.ServiceProvider.GetRequiredService<IOptions<RuntimeOptions>>().Value;
+    var logger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("DemoDataStartup");
+
+    if (!runtimeOptions.Database.SeedDemoDataOnStartup)
+    {
+        logger.LogInformation("Demo data seeding on startup is disabled.");
+        return;
+    }
+
+    var seeder = scope.ServiceProvider.GetRequiredService<DemoDataSeeder>();
+    var result = await seeder.SeedAsync(resetExistingData: false, CancellationToken.None);
+    logger.LogInformation(
+        "Demo data seeding completed with status {Status}. Resources: {ResourceCount}, Comments: {CommentCount}.",
+        result.Status,
+        result.ResourceCount,
+        result.CommentCount);
 }

--- a/src/BlijvenLeren.App/appsettings.json
+++ b/src/BlijvenLeren.App/appsettings.json
@@ -11,6 +11,7 @@
   "Runtime": {
     "Database": {
       "ApplyMigrationsOnStartup": false,
+      "SeedDemoDataOnStartup": false,
       "Host": "localhost",
       "Port": 5432
     },


### PR DESCRIPTION
## Summary
- add a demo-data seeder that creates a small representative set of learning resources and comments
- seed demo data automatically in the compose runtime when the database is empty
- add an HTTP reseed endpoint for resetting the local walkthrough dataset
- update the docs to describe the seeded shape, startup behavior, and reset flow

## Issue
Fixes #18

## Notes
- The seed workflow stays inside the application data layer so it evolves with the EF Core model already in the repo.
- Startup seeding is opt-in through Runtime__Database__SeedDemoDataOnStartup; compose enables it, local non-Docker runs do not.

## Verification
- dotnet build BlijvenLeren.sln -c Release
- docker compose down -v && docker compose up --build -d
- POST /api/demo/seed-data returned 200 with status: unchanged, esourceCount: 3, and commentCount: 6 after clean startup seeding
- POST /api/demo/seed-data?reset=true returned 200 with status: reseeded and the same predictable counts