### PR TITLE
Implement resource CRUD vertical slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,15 @@ Useful endpoints after startup:
 - app landing page: `http://localhost:8080/`
 - app health: `http://localhost:8080/api/health`
 - dependency probe: `http://localhost:8080/api/health/dependencies`
+- browser resource list: `http://localhost:8080/LearningResources`
+- browser resource details: `http://localhost:8080/LearningResources/{id}`
+- browser resource create route: `http://localhost:8080/LearningResources/Create`
+- browser resource edit route: `http://localhost:8080/LearningResources/Edit/{id}`
 - versioned list route: `GET http://localhost:8080/api/v1/learning-resources`
 - versioned detail route: `GET http://localhost:8080/api/v1/learning-resources/{id}`
 - versioned create route: `POST http://localhost:8080/api/v1/learning-resources`
+- versioned update route: `PUT http://localhost:8080/api/v1/learning-resources/{id}`
+- versioned delete route: `DELETE http://localhost:8080/api/v1/learning-resources/{id}`
 - persistence smoke path: `POST http://localhost:8080/api/health/persistence-smoke`
 - demo data reseed path: `POST http://localhost:8080/api/demo/seed-data?reset=true`
 - current-user route: `GET http://localhost:8080/api/auth/me`
@@ -128,6 +134,13 @@ Issue `#8` adds the first domain-contract slice:
 - list and detail responses for learning resources and comments
 - an internal-only create route with basic validation errors
 - mapping and validation tests for the new contract baseline
+
+Issue `#9` completes the first learning-resource CRUD slice:
+- browser list and details pages for seeded learning resources
+- internal-only browser create, edit, and delete flows
+- versioned update and delete API routes alongside the existing list, detail, and create routes
+- role checks enforced consistently across browser and API paths
+- integration coverage for API and browser happy paths using an in-memory test host
 
 ### Database migration workflow
 
@@ -191,6 +204,22 @@ curl -X POST "http://localhost:8080/api/v1/learning-resources" ^
   -H "Authorization: Bearer <internal_access_token>" ^
   -H "Content-Type: application/json" ^
   -d "{\"title\":\"Intro to REST APIs\",\"description\":\"Short MVP sample resource.\",\"url\":\"https://example.com/rest-api\"}"
+```
+
+Learning-resource update example:
+
+```bash
+curl -X PUT "http://localhost:8080/api/v1/learning-resources/<resource_id>" ^
+  -H "Authorization: Bearer <internal_access_token>" ^
+  -H "Content-Type: application/json" ^
+  -d "{\"title\":\"Updated REST APIs intro\",\"description\":\"Updated MVP sample resource.\",\"url\":\"https://example.com/rest-api-updated\"}"
+```
+
+Learning-resource delete example:
+
+```bash
+curl -X DELETE "http://localhost:8080/api/v1/learning-resources/<resource_id>" ^
+  -H "Authorization: Bearer <internal_access_token>"
 ```
 
 ### Demo data workflow

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,13 +46,20 @@ The runnable application code currently lives in:
 
 - `src/BlijvenLeren.App`: single ASP.NET Core Razor Pages application with minimal API endpoints
 - `BlijvenLeren.sln`: top-level solution file for local build and future expansion
-- `test/BlijvenLeren.App.Tests`: contract-mapping and validation tests for the MVP API baseline
+- `test/BlijvenLeren.App.Tests`: unit and integration tests for the current learning-resource slice
 
 Current bootstrap behavior:
 - `/` serves a placeholder browser page
 - `/api/health` serves a placeholder API health response
 
 This keeps the startup slice small while still demonstrating both browser and API access paths.
+
+Current CRUD behavior:
+- `/LearningResources` lists the seeded learning resources in the browser
+- `/LearningResources/Details/{id}` shows resource details and moderation-state comments
+- `/LearningResources/Create` and `/LearningResources/Edit/{id}` are restricted to internal users
+- `DELETE` browser behavior is triggered from the details page and enforced server-side
+- `/api/v1/learning-resources` now covers list, detail, create, update, and delete operations
 
 ## Data layer
 
@@ -111,10 +118,14 @@ The current authentication setup uses:
 
 Current protected boundaries:
 - `/protected` requires authentication
+- `/LearningResources/Create` requires the internal-user role
+- `/LearningResources/Edit/{id}` requires the internal-user role
+- delete behavior on `/LearningResources/Details/{id}` requires the internal-user role
 - `/api/demo/seed-data` requires the internal-user role
 - `/api/auth/internal` requires the internal-user role
 - `/api/auth/external` requires the external-contributor role
 - `/api/auth/me` accepts authenticated browser sessions or bearer tokens
+- `POST`, `PUT`, and `DELETE` on `/api/v1/learning-resources` require the internal-user role
 
 Flow notes:
 - browser requests challenge through the app and are redirected to Keycloak

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -36,3 +36,9 @@
 - Add update/delete contracts and handlers once the internal CRUD workflow is implemented.
 - Add explicit API versioning strategy documentation once there is more than one versioned slice.
 - Revisit whether the current EF-entity-as-domain baseline should be split further once business rules become richer.
+
+## Deferred from issue #9
+
+- Add pagination, filtering, and sorting to the resource list in browser and API views.
+- Add optimistic concurrency handling for concurrent edits and deletes.
+- Add browser automation if the UI grows beyond the current server-rendered forms and navigation.

--- a/docs/functional-requirements.md
+++ b/docs/functional-requirements.md
@@ -71,6 +71,17 @@ The main functionality shall be accessible through an API.
 ### FR-13 Browser access
 The main functionality shall be accessible through a browser-based application.
 
+## Current implementation coverage
+
+- FR-01 is implemented through `GET /api/v1/learning-resources` and `/LearningResources`.
+- FR-02 is implemented through `GET /api/v1/learning-resources/{id}` and `/LearningResources/Details/{id}`.
+- FR-03 is implemented through `POST /api/v1/learning-resources` and `/LearningResources/Create` for internal users.
+- FR-04 is implemented through `PUT /api/v1/learning-resources/{id}` and `/LearningResources/Edit/{id}` for internal users.
+- FR-05 is implemented through `DELETE /api/v1/learning-resources/{id}` and the delete action on `/LearningResources/Details/{id}` for internal users.
+- FR-11 is implemented through the local Keycloak-backed browser login flow and bearer-token validation.
+- FR-12 is partially implemented through the health/auth/resource API slice.
+- FR-13 is partially implemented through the current Razor Pages landing, protected, and learning-resource CRUD pages.
+
 ## Notes and implementation choices
 
 The brief mentions social login as a preference rather than an absolute requirement.  

--- a/docs/security.md
+++ b/docs/security.md
@@ -25,6 +25,8 @@ This MVP uses a local Keycloak instance to demonstrate authentication and role-b
 - Protected routes require authentication before access.
 - Role checks are enforced in the application for internal-only and external-only behavior.
 - API bearer tokens are validated against the local identity provider before protected API access is granted.
+- Browser create, edit, and delete routes for learning resources are restricted to the `internal-user` role.
+- API create, update, and delete routes for learning resources are restricted to the `internal-user` role.
 
 ## Deferred hardening
 

--- a/docs/technical-decisions.md
+++ b/docs/technical-decisions.md
@@ -211,3 +211,21 @@ Issue `#8` needs a coherent model and contract baseline with validation, but a h
 - Introduce a richer DDD-style domain layer immediately: rejected because the current scope does not yet justify the extra abstraction.
 
 ---
+
+## TD-015 Implement the first CRUD slice through Razor Pages plus minimal APIs
+**Decision**
+Deliver the first learning-resource CRUD slice through the existing Razor Pages app and the versioned minimal API surface, with the same DbContext and validation rules underneath both.
+
+**Why**
+Issue `#9` requires both browser and API access, but the current MVP still favors one combined application over a split frontend/backend architecture. Reusing the same application slice keeps behavior reviewable and avoids inventing a second UI/API integration layer too early.
+
+**Impact**
+- Internal-user create, edit, and delete behavior is now available through both browser and API paths.
+- Validation and mapping stay centralized instead of diverging between UI and API handlers.
+- The browser UI remains intentionally simple server-rendered Razor Pages rather than a separate SPA.
+
+**Rejected alternatives**
+- Build a separate frontend client for CRUD now: rejected because it adds architecture that the sample scope does not require.
+- Implement only the API and defer browser CRUD: rejected because the issue explicitly requires both access paths.
+
+---

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -1,0 +1,39 @@
+# Testing Strategy
+
+## Current approach
+
+The MVP currently uses automated tests at two levels:
+
+- focused unit tests for learning-resource contract mapping and request validation
+- integration tests for the first CRUD vertical slice across both API and browser routes
+
+## Test stack
+
+- `xUnit` for the test runner
+- `Microsoft.AspNetCore.Mvc.Testing` for in-process application hosting
+- `Microsoft.EntityFrameworkCore.InMemory` for isolated integration-test persistence
+
+## Current coverage
+
+Issue `#8` coverage:
+- request validation for create requests
+- contract mapping for list, detail, and create behavior
+
+Issue `#9` coverage:
+- seeded resource list/detail API responses
+- internal-user create, update, and delete API happy paths
+- role-based API denial for external contributors
+- seeded browser list rendering
+- internal-user create, edit, and delete browser happy paths through Razor Pages forms
+
+## Deliberate limits
+
+- The integration tests replace PostgreSQL with EF Core InMemory, so they verify application behavior rather than provider-specific SQL behavior.
+- The browser coverage is server-rendered Razor Pages exercised through HTTP, not full browser automation.
+- The OIDC login redirect against local Keycloak is not part of the automated suite yet; it is still verified manually in the compose runtime.
+
+## Follow-up direction
+
+- Add provider-realistic persistence tests if query complexity increases.
+- Add browser automation if the UI becomes more interactive than basic Razor Pages forms.
+- Add compose-level smoke checks once CI/runtime setup becomes part of the assignment scope.

--- a/src/BlijvenLeren.App/Contracts/V1/LearningResourceContracts.cs
+++ b/src/BlijvenLeren.App/Contracts/V1/LearningResourceContracts.cs
@@ -5,6 +5,11 @@ public sealed record CreateLearningResourceRequest(
     string? Description,
     string? Url);
 
+public sealed record UpdateLearningResourceRequest(
+    string? Title,
+    string? Description,
+    string? Url);
+
 public sealed record LearningResourceListItemResponse(
     Guid Id,
     string Title,

--- a/src/BlijvenLeren.App/Features/LearningResources/LearningResourceContractMapper.cs
+++ b/src/BlijvenLeren.App/Features/LearningResources/LearningResourceContractMapper.cs
@@ -43,6 +43,13 @@ public static class LearningResourceContractMapper
         };
     }
 
+    public static void ApplyUpdate(LearningResource resource, UpdateLearningResourceRequest request)
+    {
+        resource.Title = request.Title!.Trim();
+        resource.Description = request.Description!.Trim();
+        resource.Url = request.Url!.Trim();
+    }
+
     private static CommentResponse ToCommentResponse(Comment comment)
     {
         return new CommentResponse(

--- a/src/BlijvenLeren.App/Features/LearningResources/LearningResourceRequestValidator.cs
+++ b/src/BlijvenLeren.App/Features/LearningResources/LearningResourceRequestValidator.cs
@@ -6,21 +6,31 @@ public static class LearningResourceRequestValidator
 {
     public static Dictionary<string, string[]> Validate(CreateLearningResourceRequest request)
     {
+        return Validate(request.Title, request.Description, request.Url);
+    }
+
+    public static Dictionary<string, string[]> Validate(UpdateLearningResourceRequest request)
+    {
+        return Validate(request.Title, request.Description, request.Url);
+    }
+
+    private static Dictionary<string, string[]> Validate(string? title, string? description, string? url)
+    {
         var errors = new Dictionary<string, string[]>(StringComparer.Ordinal);
 
-        AddErrorIfInvalid(errors, nameof(request.Title), request.Title, 200, "Title is required.");
-        AddErrorIfInvalid(errors, nameof(request.Description), request.Description, 2000, "Description is required.");
-        AddErrorIfInvalid(errors, nameof(request.Url), request.Url, 2048, "Url is required.");
+        AddErrorIfInvalid(errors, "Title", title, 200, "Title is required.");
+        AddErrorIfInvalid(errors, "Description", description, 2000, "Description is required.");
+        AddErrorIfInvalid(errors, "Url", url, 2048, "Url is required.");
 
         Uri? uri = null;
-        if (!string.IsNullOrWhiteSpace(request.Url)
-            && !Uri.TryCreate(request.Url.Trim(), UriKind.Absolute, out uri))
+        if (!string.IsNullOrWhiteSpace(url)
+            && !Uri.TryCreate(url.Trim(), UriKind.Absolute, out uri))
         {
-            AddError(errors, nameof(request.Url), "Url must be a valid absolute URI.");
+            AddError(errors, "Url", "Url must be a valid absolute URI.");
         }
         else if (uri is not null && uri.Scheme is not ("http" or "https"))
         {
-            AddError(errors, nameof(request.Url), "Url must use http or https.");
+            AddError(errors, "Url", "Url must use http or https.");
         }
 
         return errors;

--- a/src/BlijvenLeren.App/Pages/Index.cshtml
+++ b/src/BlijvenLeren.App/Pages/Index.cshtml
@@ -13,6 +13,9 @@
         It provides a basic landing page for the browser experience and a placeholder API health endpoint at
         <code>/api/health</code> so later vertical slices can build on a runnable foundation.
     </p>
+    <p>
+        The first browser CRUD slice now lives at <a asp-page="/LearningResources/Index"><code>/LearningResources</code></a>.
+    </p>
 </section>
 
 <section class="pb-4">
@@ -58,5 +61,6 @@
         <li>Identity provider: <code>@Model.IdentityProviderAuthority</code></li>
         <li>Dependency probe: <code>@Model.AppBaseUrl/api/health/dependencies</code></li>
         <li>Token validation route: <code>@Model.AppBaseUrl/api/auth/me</code></li>
+        <li>Browser CRUD route: <code>@Model.AppBaseUrl/LearningResources</code></li>
     </ul>
 </section>

--- a/src/BlijvenLeren.App/Pages/LearningResources/Create.cshtml
+++ b/src/BlijvenLeren.App/Pages/LearningResources/Create.cshtml
@@ -1,0 +1,41 @@
+@page
+@model BlijvenLeren.App.Pages.LearningResources.CreateModel
+@{
+    ViewData["Title"] = "Add resource";
+}
+
+<section class="py-4">
+    <h1 class="display-6 mb-3">Add learning resource</h1>
+    <p class="lead">Internal users can add a new learning resource through the browser UI.</p>
+
+    <form method="post" class="vstack gap-3">
+        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+
+        <div>
+            <label asp-for="Input.Title" class="form-label"></label>
+            <input asp-for="Input.Title" class="form-control" />
+            <span asp-validation-for="Input.Title" class="text-danger"></span>
+        </div>
+
+        <div>
+            <label asp-for="Input.Description" class="form-label"></label>
+            <textarea asp-for="Input.Description" class="form-control" rows="5"></textarea>
+            <span asp-validation-for="Input.Description" class="text-danger"></span>
+        </div>
+
+        <div>
+            <label asp-for="Input.Url" class="form-label"></label>
+            <input asp-for="Input.Url" class="form-control" />
+            <span asp-validation-for="Input.Url" class="text-danger"></span>
+        </div>
+
+        <div class="d-flex gap-2">
+            <button class="btn btn-primary" type="submit">Create</button>
+            <a class="btn btn-outline-secondary" asp-page="/LearningResources/Index">Cancel</a>
+        </div>
+    </form>
+</section>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/src/BlijvenLeren.App/Pages/LearningResources/Create.cshtml.cs
+++ b/src/BlijvenLeren.App/Pages/LearningResources/Create.cshtml.cs
@@ -1,0 +1,48 @@
+using BlijvenLeren.App.Contracts.V1;
+using BlijvenLeren.App.Data;
+using BlijvenLeren.App.Features.LearningResources;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace BlijvenLeren.App.Pages.LearningResources;
+
+[Authorize(Policy = "InternalUser")]
+public sealed class CreateModel(AppDbContext dbContext) : PageModel
+{
+    [BindProperty]
+    public LearningResourceFormModel Input { get; set; } = new();
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPostAsync(CancellationToken cancellationToken)
+    {
+        var request = new CreateLearningResourceRequest(Input.Title, Input.Description, Input.Url);
+        AddValidationErrors(LearningResourceRequestValidator.Validate(request));
+
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var resource = LearningResourceContractMapper.ToEntity(request, DateTimeOffset.UtcNow);
+        dbContext.LearningResources.Add(resource);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        TempData["StatusMessage"] = "Learning resource created.";
+        return RedirectToPage("/LearningResources/Details", new { id = resource.Id });
+    }
+
+    private void AddValidationErrors(IReadOnlyDictionary<string, string[]> errors)
+    {
+        foreach (var (fieldName, messages) in errors)
+        {
+            foreach (var message in messages)
+            {
+                ModelState.AddModelError($"Input.{fieldName}", message);
+            }
+        }
+    }
+}

--- a/src/BlijvenLeren.App/Pages/LearningResources/Details.cshtml
+++ b/src/BlijvenLeren.App/Pages/LearningResources/Details.cshtml
@@ -1,0 +1,68 @@
+@page "{id:guid}"
+@model BlijvenLeren.App.Pages.LearningResources.DetailsModel
+@{
+    ViewData["Title"] = Model.Resource?.Title ?? "Learning resource";
+}
+
+@if (Model.Resource is null)
+{
+    <section class="py-4">
+        <div class="alert alert-warning" role="alert">Learning resource not found.</div>
+    </section>
+}
+else
+{
+    <section class="py-4">
+        <div class="d-flex justify-content-between align-items-start gap-3 mb-4">
+            <div>
+                <h1 class="display-6 mb-2">@Model.Resource.Title</h1>
+                <p class="lead mb-2">@Model.Resource.Description</p>
+                <p class="mb-0">
+                    <a href="@Model.Resource.Url" target="_blank" rel="noreferrer">@Model.Resource.Url</a>
+                </p>
+            </div>
+            <span class="badge text-bg-light">@Model.Resource.CreatedUtc.ToString("yyyy-MM-dd")</span>
+        </div>
+
+        @if (Model.CanManageResources)
+        {
+            <div class="d-flex gap-2 mb-4">
+                <a class="btn btn-outline-primary" asp-page="/LearningResources/Edit" asp-route-id="@Model.Resource.Id">Edit</a>
+                <form method="post" asp-page-handler="Delete" asp-route-id="@Model.Resource.Id">
+                    <button class="btn btn-outline-danger" type="submit">Delete</button>
+                </form>
+            </div>
+        }
+
+        <h2 class="h4 mb-3">Comments</h2>
+        @if (Model.Resource.Comments.Count == 0)
+        {
+            <div class="alert alert-info" role="alert">No comments have been added yet.</div>
+        }
+        else
+        {
+            <div class="list-group">
+                @foreach (var comment in Model.Resource.Comments)
+                {
+                    <article class="list-group-item">
+                        <div class="d-flex justify-content-between align-items-start gap-3">
+                            <div>
+                                <strong>@comment.AuthorDisplayName</strong>
+                                <span class="text-muted">(@comment.AuthorType)</span>
+                            </div>
+                            <span class="badge text-bg-secondary">@comment.Status</span>
+                        </div>
+                        <p class="mt-2 mb-2">@comment.Body</p>
+                        <p class="mb-0 text-muted">
+                            Created @comment.CreatedUtc.ToString("yyyy-MM-dd HH:mm")
+                            @if (comment.ModeratedUtc is not null)
+                            {
+                                <span>| Moderated @comment.ModeratedUtc.Value.ToString("yyyy-MM-dd HH:mm")</span>
+                            }
+                        </p>
+                    </article>
+                }
+            </div>
+        }
+    </section>
+}

--- a/src/BlijvenLeren.App/Pages/LearningResources/Details.cshtml.cs
+++ b/src/BlijvenLeren.App/Pages/LearningResources/Details.cshtml.cs
@@ -1,0 +1,83 @@
+using BlijvenLeren.App.Data;
+using BlijvenLeren.App.Data.Entities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+
+namespace BlijvenLeren.App.Pages.LearningResources;
+
+public sealed class DetailsModel(AppDbContext dbContext) : PageModel
+{
+    public LearningResourceDetailsViewModel? Resource { get; private set; }
+
+    public bool CanManageResources => User.IsInRole("internal-user");
+
+    public async Task<IActionResult> OnGetAsync(Guid id, CancellationToken cancellationToken)
+    {
+        Resource = await LoadResourceAsync(id, cancellationToken);
+        return Resource is null ? NotFound() : Page();
+    }
+
+    public async Task<IActionResult> OnPostDeleteAsync(Guid id, CancellationToken cancellationToken)
+    {
+        if (!User.IsInRole("internal-user"))
+        {
+            return Forbid();
+        }
+
+        var resource = await dbContext.LearningResources
+            .SingleOrDefaultAsync(learningResource => learningResource.Id == id, cancellationToken);
+
+        if (resource is null)
+        {
+            return NotFound();
+        }
+
+        dbContext.LearningResources.Remove(resource);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        TempData["StatusMessage"] = "Learning resource deleted.";
+        return RedirectToPage("/LearningResources/Index");
+    }
+
+    private async Task<LearningResourceDetailsViewModel?> LoadResourceAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return await dbContext.LearningResources
+            .AsNoTracking()
+            .Include(resource => resource.Comments)
+            .Where(resource => resource.Id == id)
+            .Select(resource => new LearningResourceDetailsViewModel(
+                resource.Id,
+                resource.Title,
+                resource.Description,
+                resource.Url,
+                resource.CreatedUtc,
+                resource.Comments
+                    .OrderBy(comment => comment.CreatedUtc)
+                    .Select(comment => new LearningResourceCommentViewModel(
+                        comment.AuthorDisplayName,
+                        comment.AuthorType.ToString(),
+                        comment.Body,
+                        comment.Status.ToString(),
+                        comment.CreatedUtc,
+                        comment.ModeratedUtc))
+                    .ToList()))
+            .SingleOrDefaultAsync(cancellationToken);
+    }
+}
+
+public sealed record LearningResourceDetailsViewModel(
+    Guid Id,
+    string Title,
+    string Description,
+    string Url,
+    DateTimeOffset CreatedUtc,
+    IReadOnlyList<LearningResourceCommentViewModel> Comments);
+
+public sealed record LearningResourceCommentViewModel(
+    string AuthorDisplayName,
+    string AuthorType,
+    string Body,
+    string Status,
+    DateTimeOffset CreatedUtc,
+    DateTimeOffset? ModeratedUtc);

--- a/src/BlijvenLeren.App/Pages/LearningResources/Edit.cshtml
+++ b/src/BlijvenLeren.App/Pages/LearningResources/Edit.cshtml
@@ -1,0 +1,41 @@
+@page "{id:guid}"
+@model BlijvenLeren.App.Pages.LearningResources.EditModel
+@{
+    ViewData["Title"] = "Edit resource";
+}
+
+<section class="py-4">
+    <h1 class="display-6 mb-3">Edit learning resource</h1>
+    <p class="lead">Internal users can update an existing learning resource.</p>
+
+    <form method="post" class="vstack gap-3">
+        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+
+        <div>
+            <label asp-for="Input.Title" class="form-label"></label>
+            <input asp-for="Input.Title" class="form-control" />
+            <span asp-validation-for="Input.Title" class="text-danger"></span>
+        </div>
+
+        <div>
+            <label asp-for="Input.Description" class="form-label"></label>
+            <textarea asp-for="Input.Description" class="form-control" rows="5"></textarea>
+            <span asp-validation-for="Input.Description" class="text-danger"></span>
+        </div>
+
+        <div>
+            <label asp-for="Input.Url" class="form-label"></label>
+            <input asp-for="Input.Url" class="form-control" />
+            <span asp-validation-for="Input.Url" class="text-danger"></span>
+        </div>
+
+        <div class="d-flex gap-2">
+            <button class="btn btn-primary" type="submit">Save</button>
+            <a class="btn btn-outline-secondary" asp-page="/LearningResources/Details" asp-route-id="@Model.ResourceId">Cancel</a>
+        </div>
+    </form>
+</section>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/src/BlijvenLeren.App/Pages/LearningResources/Edit.cshtml.cs
+++ b/src/BlijvenLeren.App/Pages/LearningResources/Edit.cshtml.cs
@@ -1,0 +1,78 @@
+using BlijvenLeren.App.Contracts.V1;
+using BlijvenLeren.App.Data;
+using BlijvenLeren.App.Features.LearningResources;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+
+namespace BlijvenLeren.App.Pages.LearningResources;
+
+[Authorize(Policy = "InternalUser")]
+public sealed class EditModel(AppDbContext dbContext) : PageModel
+{
+    [BindProperty]
+    public LearningResourceFormModel Input { get; set; } = new();
+
+    public Guid ResourceId { get; private set; }
+
+    public async Task<IActionResult> OnGetAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var resource = await dbContext.LearningResources
+            .AsNoTracking()
+            .SingleOrDefaultAsync(learningResource => learningResource.Id == id, cancellationToken);
+
+        if (resource is null)
+        {
+            return NotFound();
+        }
+
+        ResourceId = resource.Id;
+        Input = new LearningResourceFormModel
+        {
+            Title = resource.Title,
+            Description = resource.Description,
+            Url = resource.Url
+        };
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync(Guid id, CancellationToken cancellationToken)
+    {
+        ResourceId = id;
+
+        var request = new UpdateLearningResourceRequest(Input.Title, Input.Description, Input.Url);
+        AddValidationErrors(LearningResourceRequestValidator.Validate(request));
+
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var resource = await dbContext.LearningResources
+            .SingleOrDefaultAsync(learningResource => learningResource.Id == id, cancellationToken);
+
+        if (resource is null)
+        {
+            return NotFound();
+        }
+
+        LearningResourceContractMapper.ApplyUpdate(resource, request);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        TempData["StatusMessage"] = "Learning resource updated.";
+        return RedirectToPage("/LearningResources/Details", new { id = resource.Id });
+    }
+
+    private void AddValidationErrors(IReadOnlyDictionary<string, string[]> errors)
+    {
+        foreach (var (fieldName, messages) in errors)
+        {
+            foreach (var message in messages)
+            {
+                ModelState.AddModelError($"Input.{fieldName}", message);
+            }
+        }
+    }
+}

--- a/src/BlijvenLeren.App/Pages/LearningResources/Index.cshtml
+++ b/src/BlijvenLeren.App/Pages/LearningResources/Index.cshtml
@@ -1,0 +1,57 @@
+@page
+@model BlijvenLeren.App.Pages.LearningResources.IndexModel
+@{
+    ViewData["Title"] = "Learning resources";
+}
+
+<section class="py-4">
+    <div class="d-flex justify-content-between align-items-start gap-3 mb-4">
+        <div>
+            <h1 class="display-6 mb-2">Learning resources</h1>
+            <p class="lead mb-0">The browser UI for the first CRUD vertical slice.</p>
+        </div>
+        @if (Model.CanManageResources)
+        {
+            <a class="btn btn-primary" asp-page="/LearningResources/Create">Add resource</a>
+        }
+    </div>
+
+    @if (Model.Resources.Count == 0)
+    {
+        <div class="alert alert-info" role="alert">
+            No learning resources are available yet.
+        </div>
+    }
+    else
+    {
+        <div class="row g-3">
+            @foreach (var resource in Model.Resources)
+            {
+                <div class="col-12">
+                    <article class="card h-100">
+                        <div class="card-body">
+                            <div class="d-flex justify-content-between align-items-start gap-3">
+                                <div>
+                                    <h2 class="h4 mb-2">
+                                        <a asp-page="/LearningResources/Details" asp-route-id="@resource.Id">
+                                            @resource.Title
+                                        </a>
+                                    </h2>
+                                    <p class="mb-2">@resource.Description</p>
+                                    <p class="mb-2">
+                                        <a href="@resource.Url" target="_blank" rel="noreferrer">@resource.Url</a>
+                                    </p>
+                                </div>
+                                <span class="badge text-bg-light">@resource.CreatedUtc.ToString("yyyy-MM-dd")</span>
+                            </div>
+                            <p class="mb-0 text-muted">
+                                Approved comments: @resource.ApprovedCommentCount |
+                                Pending comments: @resource.PendingCommentCount
+                            </p>
+                        </div>
+                    </article>
+                </div>
+            }
+        </div>
+    }
+</section>

--- a/src/BlijvenLeren.App/Pages/LearningResources/Index.cshtml.cs
+++ b/src/BlijvenLeren.App/Pages/LearningResources/Index.cshtml.cs
@@ -1,0 +1,38 @@
+using BlijvenLeren.App.Data;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+
+namespace BlijvenLeren.App.Pages.LearningResources;
+
+public sealed class IndexModel(AppDbContext dbContext) : PageModel
+{
+    public IReadOnlyList<LearningResourceListItemViewModel> Resources { get; private set; } = [];
+
+    public bool CanManageResources => User.IsInRole("internal-user");
+
+    public async Task OnGetAsync(CancellationToken cancellationToken)
+    {
+        Resources = await dbContext.LearningResources
+            .AsNoTracking()
+            .Include(resource => resource.Comments)
+            .OrderBy(resource => resource.Title)
+            .Select(resource => new LearningResourceListItemViewModel(
+                resource.Id,
+                resource.Title,
+                resource.Description,
+                resource.Url,
+                resource.CreatedUtc,
+                resource.Comments.Count(comment => comment.Status == Data.Entities.CommentStatus.Approved),
+                resource.Comments.Count(comment => comment.Status == Data.Entities.CommentStatus.Pending)))
+            .ToListAsync(cancellationToken);
+    }
+}
+
+public sealed record LearningResourceListItemViewModel(
+    Guid Id,
+    string Title,
+    string Description,
+    string Url,
+    DateTimeOffset CreatedUtc,
+    int ApprovedCommentCount,
+    int PendingCommentCount);

--- a/src/BlijvenLeren.App/Pages/LearningResources/LearningResourceFormModel.cs
+++ b/src/BlijvenLeren.App/Pages/LearningResources/LearningResourceFormModel.cs
@@ -1,0 +1,10 @@
+namespace BlijvenLeren.App.Pages.LearningResources;
+
+public sealed class LearningResourceFormModel
+{
+    public string? Title { get; set; }
+
+    public string? Description { get; set; }
+
+    public string? Url { get; set; }
+}

--- a/src/BlijvenLeren.App/Pages/Protected.cshtml
+++ b/src/BlijvenLeren.App/Pages/Protected.cshtml
@@ -18,7 +18,9 @@
 
     <p>Browser-protected route: <code>/protected</code></p>
     <p>API token validation route: <code>/api/auth/me</code></p>
+    <p>Browser CRUD route: <code>/LearningResources</code></p>
     <p>Internal-only route: <code>/api/auth/internal</code></p>
     <p>External-only route: <code>/api/auth/external</code></p>
     <p>Internal-only seed reset: <code>POST /api/demo/seed-data?reset=true</code></p>
+    <p>Internal-only browser create route: <code>/LearningResources/Create</code></p>
 </section>

--- a/src/BlijvenLeren.App/Pages/Shared/_Layout.cshtml
+++ b/src/BlijvenLeren.App/Pages/Shared/_Layout.cshtml
@@ -24,6 +24,9 @@
                             <a class="nav-link text-dark" asp-area="" asp-page="/Index">Home</a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-page="/LearningResources/Index">Resources</a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-page="/Protected">Protected</a>
                         </li>
                     </ul>
@@ -39,6 +42,10 @@
     </header>
     <div class="container">
         <main role="main" class="pb-3">
+            @if (TempData["StatusMessage"] is string statusMessage)
+            {
+                <div class="alert alert-success mt-3" role="alert">@statusMessage</div>
+            }
             @RenderBody()
         </main>
     </div>

--- a/src/BlijvenLeren.App/Program.Partial.cs
+++ b/src/BlijvenLeren.App/Program.Partial.cs
@@ -1,0 +1,1 @@
+public partial class Program;

--- a/src/BlijvenLeren.App/Program.cs
+++ b/src/BlijvenLeren.App/Program.cs
@@ -278,6 +278,53 @@ app.MapGet(
     })
     .WithSummary("Get one learning resource with its comments using the versioned API contract.");
 
+app.MapPut(
+    "/api/v1/learning-resources/{id:guid}",
+    async (Guid id, UpdateLearningResourceRequest request, AppDbContext dbContext, CancellationToken cancellationToken) =>
+    {
+        var errors = LearningResourceRequestValidator.Validate(request);
+        if (errors.Count > 0)
+        {
+            return Results.ValidationProblem(errors);
+        }
+
+        var resource = await dbContext.LearningResources
+            .Include(learningResource => learningResource.Comments)
+            .SingleOrDefaultAsync(learningResource => learningResource.Id == id, cancellationToken);
+
+        if (resource is null)
+        {
+            return Results.NotFound();
+        }
+
+        LearningResourceContractMapper.ApplyUpdate(resource, request);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Results.Ok(LearningResourceContractMapper.ToDetailResponse(resource));
+    })
+    .RequireAuthorization("InternalUser")
+    .WithSummary("Update a learning resource with MVP validation rules.");
+
+app.MapDelete(
+    "/api/v1/learning-resources/{id:guid}",
+    async (Guid id, AppDbContext dbContext, CancellationToken cancellationToken) =>
+    {
+        var resource = await dbContext.LearningResources
+            .SingleOrDefaultAsync(learningResource => learningResource.Id == id, cancellationToken);
+
+        if (resource is null)
+        {
+            return Results.NotFound();
+        }
+
+        dbContext.LearningResources.Remove(resource);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Results.NoContent();
+    })
+    .RequireAuthorization("InternalUser")
+    .WithSummary("Delete a learning resource.");
+
 app.MapPost(
     "/api/health/persistence-smoke",
     async (AppDbContext dbContext, CancellationToken cancellationToken) =>

--- a/test/BlijvenLeren.App.Tests/ApiResourceCrudIntegrationTests.cs
+++ b/test/BlijvenLeren.App.Tests/ApiResourceCrudIntegrationTests.cs
@@ -1,0 +1,98 @@
+using System.Net;
+using System.Net.Http.Json;
+using BlijvenLeren.App.Contracts.V1;
+using BlijvenLeren.App.Tests.Infrastructure;
+
+namespace BlijvenLeren.App.Tests;
+
+public sealed class ApiResourceCrudIntegrationTests : IClassFixture<TestApplicationFactory>
+{
+    private readonly TestApplicationFactory _factory;
+
+    public ApiResourceCrudIntegrationTests(TestApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task ListAndDetail_ReturnSeededResources()
+    {
+        using var client = _factory.CreateClient();
+
+        var list = await client.GetFromJsonAsync<List<LearningResourceListItemResponse>>("/api/v1/learning-resources");
+        Assert.NotNull(list);
+        Assert.Equal(2, list.Count);
+
+        var detail = await client.GetFromJsonAsync<LearningResourceDetailResponse>(
+            "/api/v1/learning-resources/901a31cc-3ec7-4e8b-93cb-9cb6c49054af");
+
+        Assert.NotNull(detail);
+        Assert.Equal("API Design Basics", detail.Title);
+        Assert.Single(detail.Comments);
+    }
+
+    [Fact]
+    public async Task InternalUser_CanCreateUpdateAndDeleteResource()
+    {
+        using var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Test-User", "internal.demo");
+        client.DefaultRequestHeaders.Add("X-Test-Roles", "internal-user");
+
+        var createResponse = await client.PostAsJsonAsync(
+            "/api/v1/learning-resources",
+            new CreateLearningResourceRequest(
+                "Resource from integration test",
+                "Created through the issue #9 API test.",
+                "https://example.com/integration-create"));
+
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+        var created = await createResponse.Content.ReadFromJsonAsync<LearningResourceDetailResponse>();
+        Assert.NotNull(created);
+
+        var updateResponse = await client.PutAsJsonAsync(
+            $"/api/v1/learning-resources/{created.Id}",
+            new UpdateLearningResourceRequest(
+                "Updated resource title",
+                "Updated description",
+                "https://example.com/integration-update"));
+
+        Assert.Equal(HttpStatusCode.OK, updateResponse.StatusCode);
+        var updated = await updateResponse.Content.ReadFromJsonAsync<LearningResourceDetailResponse>();
+        Assert.NotNull(updated);
+        Assert.Equal("Updated resource title", updated.Title);
+
+        var deleteResponse = await client.DeleteAsync($"/api/v1/learning-resources/{created.Id}");
+        Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+
+        var notFoundResponse = await client.GetAsync($"/api/v1/learning-resources/{created.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, notFoundResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task ExternalUser_CannotManageResources()
+    {
+        using var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Test-User", "external.demo");
+        client.DefaultRequestHeaders.Add("X-Test-Roles", "external-contributor");
+
+        var createResponse = await client.PostAsJsonAsync(
+            "/api/v1/learning-resources",
+            new CreateLearningResourceRequest(
+                "Blocked create",
+                "Should not be accepted.",
+                "https://example.com/blocked-create"));
+
+        var updateResponse = await client.PutAsJsonAsync(
+            "/api/v1/learning-resources/901a31cc-3ec7-4e8b-93cb-9cb6c49054af",
+            new UpdateLearningResourceRequest(
+                "Blocked update",
+                "Should not be accepted.",
+                "https://example.com/blocked-update"));
+
+        var deleteResponse = await client.DeleteAsync("/api/v1/learning-resources/901a31cc-3ec7-4e8b-93cb-9cb6c49054af");
+
+        Assert.Equal(HttpStatusCode.Forbidden, createResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, updateResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, deleteResponse.StatusCode);
+    }
+}

--- a/test/BlijvenLeren.App.Tests/BlijvenLeren.App.Tests.csproj
+++ b/test/BlijvenLeren.App.Tests/BlijvenLeren.App.Tests.csproj
@@ -9,6 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">

--- a/test/BlijvenLeren.App.Tests/BrowserResourceCrudIntegrationTests.cs
+++ b/test/BlijvenLeren.App.Tests/BrowserResourceCrudIntegrationTests.cs
@@ -1,0 +1,117 @@
+using System.Net;
+using System.Text.RegularExpressions;
+using BlijvenLeren.App.Tests.Infrastructure;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace BlijvenLeren.App.Tests;
+
+public sealed partial class BrowserResourceCrudIntegrationTests : IClassFixture<TestApplicationFactory>
+{
+    private readonly TestApplicationFactory _factory;
+
+    public BrowserResourceCrudIntegrationTests(TestApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task ListingPage_RendersSeededResources()
+    {
+        using var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/LearningResources");
+        var html = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("API Design Basics", html);
+        Assert.Contains("Browser Accessibility Checklist", html);
+    }
+
+    [Fact]
+    public async Task InternalUser_CanCreateEditAndDeleteThroughBrowser()
+    {
+        using var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+        client.DefaultRequestHeaders.Add("X-Test-User", "internal.demo");
+        client.DefaultRequestHeaders.Add("X-Test-Roles", "internal-user");
+
+        var createGet = await client.GetAsync("/LearningResources/Create");
+        var createToken = await ExtractRequestVerificationTokenAsync(createGet);
+        var createResponse = await client.PostAsync(
+            "/LearningResources/Create",
+            BuildFormContent(
+                createToken,
+                new Dictionary<string, string>
+                {
+                    ["Input.Title"] = "Browser-created resource",
+                    ["Input.Description"] = "Created through the Razor Pages happy-path test.",
+                    ["Input.Url"] = "https://example.com/browser-create"
+                }));
+
+        Assert.Equal(HttpStatusCode.Redirect, createResponse.StatusCode);
+        var createdLocation = createResponse.Headers.Location;
+        Assert.NotNull(createdLocation);
+        var resourceId = createdLocation.OriginalString.Split('/', StringSplitOptions.RemoveEmptyEntries)[^1];
+
+        var detailsResponse = await client.GetAsync(createdLocation);
+        var detailsHtml = await detailsResponse.Content.ReadAsStringAsync();
+        Assert.Contains("Browser-created resource", detailsHtml);
+
+        var editLocation = $"/LearningResources/Edit/{resourceId}";
+        var editGet = await client.GetAsync(editLocation);
+        var editToken = await ExtractRequestVerificationTokenAsync(editGet);
+        var editResponse = await client.PostAsync(
+            editLocation,
+            BuildFormContent(
+                editToken,
+                new Dictionary<string, string>
+                {
+                    ["Input.Title"] = "Browser-updated resource",
+                    ["Input.Description"] = "Updated through the Razor Pages happy-path test.",
+                    ["Input.Url"] = "https://example.com/browser-update"
+                }));
+
+        Assert.Equal(HttpStatusCode.Redirect, editResponse.StatusCode);
+        var updatedLocation = editResponse.Headers.Location;
+        Assert.NotNull(updatedLocation);
+
+        var updatedDetailsResponse = await client.GetAsync(updatedLocation);
+        var updatedDetailsHtml = await updatedDetailsResponse.Content.ReadAsStringAsync();
+        Assert.Contains("Browser-updated resource", updatedDetailsHtml);
+
+        var deleteGet = await client.GetAsync(updatedLocation);
+        var deleteToken = await ExtractRequestVerificationTokenAsync(deleteGet);
+        var deleteResponse = await client.PostAsync(
+            $"{updatedLocation}?handler=Delete",
+            BuildFormContent(deleteToken, new Dictionary<string, string>()));
+
+        Assert.Equal(HttpStatusCode.Redirect, deleteResponse.StatusCode);
+
+        var deletedDetailsResponse = await client.GetAsync(updatedLocation);
+        Assert.Equal(HttpStatusCode.NotFound, deletedDetailsResponse.StatusCode);
+    }
+
+    private static FormUrlEncodedContent BuildFormContent(string requestVerificationToken, Dictionary<string, string> fields)
+    {
+        var formFields = new Dictionary<string, string>(fields)
+        {
+            ["__RequestVerificationToken"] = requestVerificationToken
+        };
+
+        return new FormUrlEncodedContent(formFields);
+    }
+
+    private static async Task<string> ExtractRequestVerificationTokenAsync(HttpResponseMessage response)
+    {
+        var html = await response.Content.ReadAsStringAsync();
+        var match = RequestVerificationTokenRegex().Match(html);
+        Assert.True(match.Success, "Expected an antiforgery token in the rendered HTML.");
+
+        return match.Groups["token"].Value;
+    }
+
+    [GeneratedRegex("<input name=\"__RequestVerificationToken\" type=\"hidden\" value=\"(?<token>[^\"]+)\" ?/?>")]
+    private static partial Regex RequestVerificationTokenRegex();
+}

--- a/test/BlijvenLeren.App.Tests/Infrastructure/TestApplicationFactory.cs
+++ b/test/BlijvenLeren.App.Tests/Infrastructure/TestApplicationFactory.cs
@@ -1,0 +1,122 @@
+using BlijvenLeren.App.Data;
+using BlijvenLeren.App.Data.Entities;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace BlijvenLeren.App.Tests.Infrastructure;
+
+public sealed class TestApplicationFactory : WebApplicationFactory<Program>
+{
+    private readonly string _databaseName = $"blijvenleren-tests-{Guid.NewGuid():N}";
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Development");
+
+        builder.ConfigureAppConfiguration((_, configBuilder) =>
+        {
+            configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Runtime:Database:ApplyMigrationsOnStartup"] = "false",
+                ["Runtime:Database:SeedDemoDataOnStartup"] = "false"
+            });
+        });
+
+        builder.ConfigureServices(services =>
+        {
+            var dbContextDescriptors = services
+                .Where(descriptor =>
+                    descriptor.ServiceType == typeof(DbContextOptions<AppDbContext>)
+                    || descriptor.ServiceType == typeof(AppDbContext)
+                    || (descriptor.ServiceType.IsGenericType
+                        && descriptor.ServiceType.GetGenericTypeDefinition() == typeof(IDbContextOptionsConfiguration<>)
+                        && descriptor.ServiceType.GenericTypeArguments[0] == typeof(AppDbContext)))
+                .ToList();
+
+            foreach (var descriptor in dbContextDescriptors)
+            {
+                services.Remove(descriptor);
+            }
+
+            services.AddDbContext<AppDbContext>(options =>
+                options.UseInMemoryDatabase(_databaseName));
+
+            services.AddAuthentication(options =>
+                {
+                    options.DefaultAuthenticateScheme = TestAuthHandler.SchemeName;
+                    options.DefaultChallengeScheme = TestAuthHandler.SchemeName;
+                    options.DefaultForbidScheme = TestAuthHandler.SchemeName;
+                    options.DefaultSignInScheme = TestAuthHandler.SchemeName;
+                    options.DefaultSignOutScheme = TestAuthHandler.SchemeName;
+                })
+                .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                    TestAuthHandler.SchemeName,
+                    _ => { });
+
+            using var scope = services.BuildServiceProvider().CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            dbContext.Database.EnsureDeleted();
+            dbContext.Database.EnsureCreated();
+            Seed(dbContext);
+        });
+    }
+
+    private static void Seed(AppDbContext dbContext)
+    {
+        if (dbContext.LearningResources.Any())
+        {
+            return;
+        }
+
+        dbContext.LearningResources.AddRange(
+            new LearningResource
+            {
+                Id = Guid.Parse("901a31cc-3ec7-4e8b-93cb-9cb6c49054af"),
+                Title = "API Design Basics",
+                Description = "Compact guide to resource-oriented HTTP APIs.",
+                Url = "https://example.com/api-design-basics",
+                CreatedUtc = DateTimeOffset.Parse("2026-03-10T08:00:00Z"),
+                Comments =
+                [
+                    new Comment
+                    {
+                        Id = Guid.Parse("e2c7c846-36cf-4ac7-ae3d-34e98837031c"),
+                        AuthorDisplayName = "Internal Reviewer",
+                        AuthorType = CommentAuthorType.Internal,
+                        Body = "Good primer for the API-first part of the demo.",
+                        Status = CommentStatus.Approved,
+                        CreatedUtc = DateTimeOffset.Parse("2026-03-10T08:15:00Z"),
+                        ModeratedUtc = DateTimeOffset.Parse("2026-03-10T08:15:00Z")
+                    }
+                ]
+            },
+            new LearningResource
+            {
+                Id = Guid.Parse("f116d693-f390-45ec-8d0b-23f6784d65b4"),
+                Title = "Browser Accessibility Checklist",
+                Description = "Review checklist for form semantics and keyboard access.",
+                Url = "https://example.com/browser-accessibility",
+                CreatedUtc = DateTimeOffset.Parse("2026-03-10T09:00:00Z"),
+                Comments =
+                [
+                    new Comment
+                    {
+                        Id = Guid.Parse("6b8b684d-a9d7-4b3f-8ebf-12d6736103f4"),
+                        AuthorDisplayName = "External Contributor",
+                        AuthorType = CommentAuthorType.External,
+                        Body = "Could be useful when the UI grows beyond simple forms.",
+                        Status = CommentStatus.Pending,
+                        CreatedUtc = DateTimeOffset.Parse("2026-03-10T09:30:00Z")
+                    }
+                ]
+            });
+
+        dbContext.SaveChanges();
+    }
+}

--- a/test/BlijvenLeren.App.Tests/Infrastructure/TestAuthHandler.cs
+++ b/test/BlijvenLeren.App.Tests/Infrastructure/TestAuthHandler.cs
@@ -1,0 +1,44 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging;
+
+namespace BlijvenLeren.App.Tests.Infrastructure;
+
+public sealed class TestAuthHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder)
+    : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    public const string SchemeName = "Test";
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue("X-Test-User", out var username) || string.IsNullOrWhiteSpace(username))
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.Name, username.ToString()),
+            new("preferred_username", username.ToString())
+        };
+
+        if (Request.Headers.TryGetValue("X-Test-Roles", out var rolesHeader))
+        {
+            foreach (var role in rolesHeader.ToString().Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                claims.Add(new Claim(ClaimTypes.Role, role));
+            }
+        }
+
+        var identity = new ClaimsIdentity(claims, SchemeName);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, SchemeName);
+
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}


### PR DESCRIPTION
## Summary
- add the first end-to-end learning-resource CRUD slice across minimal APIs and Razor Pages
- enforce internal-user role checks for browser and API create/edit/delete operations
- add in-memory integration coverage for API and browser happy paths and document the implemented scope

Fixes #9