### PR TITLE
Add external comment moderation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Useful endpoints after startup:
 - versioned update route: `PUT http://localhost:8080/api/v1/learning-resources/{id}`
 - versioned delete route: `DELETE http://localhost:8080/api/v1/learning-resources/{id}`
 - comment create route: `POST http://localhost:8080/api/v1/learning-resources/{id}/comments`
+- pending comment list route: `GET http://localhost:8080/api/v1/comments/pending`
+- comment moderation route: `POST http://localhost:8080/api/v1/comments/{id}/moderation`
 - persistence smoke path: `POST http://localhost:8080/api/health/persistence-smoke`
 - demo data reseed path: `POST http://localhost:8080/api/demo/seed-data?reset=true`
 - current-user route: `GET http://localhost:8080/api/auth/me`
@@ -148,6 +150,12 @@ Issue `#10` adds the first comment-submission slice:
 - internal-user comments are auto-approved and show up immediately in normal resource views
 - external-contributor comments are stored as pending for the later moderation workflow
 - comment owner identity is now stored alongside display metadata for future moderation decisions
+
+Issue `#11` adds the moderation workflow:
+- internal users can review pending external comments through the API and an internal browser page
+- pending external comments can be approved or rejected with server-side transition rules
+- approved external comments become visible in the normal resource detail views
+- rejected external comments remain hidden from the normal resource detail views
 
 ### Database migration workflow
 
@@ -240,7 +248,21 @@ curl -X POST "http://localhost:8080/api/v1/learning-resources/<resource_id>/comm
 
 Comment visibility note:
 - internal-user comments are returned immediately in the normal resource detail responses
-- external-contributor comments are stored as `Pending` and are not shown in the normal detail responses until moderation work is implemented
+- external-contributor comments are stored as `Pending` and are not shown in the normal detail responses until an internal moderator approves them
+
+Moderation examples:
+
+```bash
+curl "http://localhost:8080/api/v1/comments/pending" ^
+  -H "Authorization: Bearer <internal_access_token>"
+```
+
+```bash
+curl -X POST "http://localhost:8080/api/v1/comments/<comment_id>/moderation" ^
+  -H "Authorization: Bearer <internal_access_token>" ^
+  -H "Content-Type: application/json" ^
+  -d "{\"action\":\"approve\"}"
+```
 
 ### Demo data workflow
 

--- a/diagrams/auth-sequence.mmd
+++ b/diagrams/auth-sequence.mmd
@@ -1,6 +1,7 @@
 sequenceDiagram
     autonumber
     actor User
+    actor Moderator as Internal Moderator
     participant Web as Web App
     participant IDP as Identity Provider
     participant DB as Database
@@ -18,3 +19,16 @@ sequenceDiagram
     Web->>DB: Read or write resource/comment
     DB-->>Web: Result
     Web-->>User: Protected response
+
+    User->>Web: Submit external comment
+    Web->>DB: Store comment as Pending
+    DB-->>Web: Pending comment saved
+    Web-->>User: Comment accepted but hidden from public view
+
+    Moderator->>Web: Open moderation queue
+    Web->>DB: Read pending external comments
+    DB-->>Web: Pending queue
+    Moderator->>Web: Approve or reject comment
+    Web->>DB: Update comment status and moderated timestamp
+    DB-->>Web: Moderation result
+    Web-->>Moderator: Updated moderation response

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,6 +68,13 @@ Current comment behavior:
 - external-contributor comments are saved as `Pending`
 - normal resource detail views currently expose only approved comments
 
+Current moderation behavior:
+- internal users can review pending external comments through `GET /api/v1/comments/pending`
+- the browser UI exposes the same queue at `/Moderation/Comments`
+- moderation actions go through `POST /api/v1/comments/{id}/moderation` or the browser approve/reject forms
+- only pending external comments can transition to `Approved` or `Rejected`
+- moderation timestamps are recorded when an internal user makes the decision
+
 ## Data layer
 
 The current persistence implementation uses:
@@ -129,12 +136,15 @@ Current protected boundaries:
 - `/LearningResources/Edit/{id}` requires the internal-user role
 - delete behavior on `/LearningResources/Details/{id}` requires the internal-user role
 - comment submission on `/LearningResources/Details/{id}` requires authentication
+- `/Moderation/Comments` requires the internal-user role
 - `/api/demo/seed-data` requires the internal-user role
 - `/api/auth/internal` requires the internal-user role
 - `/api/auth/external` requires the external-contributor role
 - `/api/auth/me` accepts authenticated browser sessions or bearer tokens
 - `POST`, `PUT`, and `DELETE` on `/api/v1/learning-resources` require the internal-user role
 - `POST /api/v1/learning-resources/{id}/comments` requires authentication
+- `GET /api/v1/comments/pending` requires the internal-user role
+- `POST /api/v1/comments/{id}/moderation` requires the internal-user role
 
 Flow notes:
 - browser requests challenge through the app and are redirected to Keycloak

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -47,4 +47,9 @@
 
 - Add edit and delete behavior for comments once comment ownership UX is defined.
 - Add anti-spam or rate-limit controls for comment submission.
-- Add dedicated internal review screens for pending comments in issue `#11`.
+
+## Deferred from issue #11
+
+- Add moderation audit history beyond the current status and timestamp fields.
+- Add bulk approval or rejection operations if the queue grows.
+- Add richer moderator context such as linked resource excerpts or filters once the queue becomes larger.

--- a/docs/functional-requirements.md
+++ b/docs/functional-requirements.md
@@ -80,6 +80,9 @@ The main functionality shall be accessible through a browser-based application.
 - FR-05 is implemented through `DELETE /api/v1/learning-resources/{id}` and the delete action on `/LearningResources/Details/{id}` for internal users.
 - FR-06 is implemented through `POST /api/v1/learning-resources/{id}/comments` and the comment form on `/LearningResources/Details/{id}` for authenticated users.
 - FR-07 is implemented by auto-approving internal-user comments on submission so they appear immediately in the normal resource detail views.
+- FR-08 is implemented by storing external comments as `Pending` and excluding them from the normal resource detail views until they are approved.
+- FR-09 is implemented through `GET /api/v1/comments/pending` and `/Moderation/Comments` for internal users.
+- FR-10 is implemented through `POST /api/v1/comments/{id}/moderation` and the approve/reject actions on `/Moderation/Comments` for internal users.
 - FR-11 is implemented through the local Keycloak-backed browser login flow and bearer-token validation.
 - FR-12 is partially implemented through the health/auth/resource API slice.
 - FR-13 is partially implemented through the current Razor Pages landing, protected, and learning-resource CRUD pages.

--- a/docs/security.md
+++ b/docs/security.md
@@ -29,6 +29,8 @@ This MVP uses a local Keycloak instance to demonstrate authentication and role-b
 - API create, update, and delete routes for learning resources are restricted to the `internal-user` role.
 - Comment submission requires an authenticated browser session or bearer token.
 - External comments are stored as pending instead of being published immediately in the normal resource views.
+- Pending-comment review and moderation actions are restricted to the `internal-user` role.
+- Server-side moderation rules reject attempts to moderate internal comments or already-moderated comments.
 
 ## Deferred hardening
 

--- a/docs/technical-decisions.md
+++ b/docs/technical-decisions.md
@@ -247,3 +247,21 @@ Issue `#10` needs role-aware publication behavior plus metadata that future mode
 - Delay ownership metadata until moderation is implemented: rejected because it would create avoidable schema churn and weaker auditability.
 
 ---
+
+## TD-017 Keep moderation as an explicit internal workflow with server-side transition rules
+**Decision**
+Implement pending-comment review as an internal moderation queue with explicit approve/reject actions, and enforce state transitions on the server so only pending external comments can be moderated.
+
+**Why**
+Issue `#11` requires review and moderation flows, but the MVP still needs a simple, reviewable design. An explicit queue plus one moderation action endpoint/page keeps the behavior easy to reason about and prevents UI-only assumptions from becoming security bugs.
+
+**Impact**
+- Internal moderators now have one clear browser page and one API surface for moderation.
+- Approved comments become visible through the existing resource detail reads without duplicating comment-query logic.
+- Repeated or invalid moderation attempts return conflicts instead of silently mutating comment state.
+
+**Rejected alternatives**
+- Auto-approve external comments after submission: rejected because it bypasses the requirement entirely.
+- Allow moderation from multiple ad hoc pages first: rejected because it spreads security-sensitive state transitions across the UI too early.
+
+---

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -33,6 +33,12 @@ Issue `#10` coverage:
 - internal-user browser comment submission showing the new comment immediately
 - external-user browser comment submission succeeding without surfacing the pending comment yet
 
+Issue `#11` coverage:
+- internal-user pending-comment list API reads
+- internal-user approve and reject moderation API paths
+- invalid moderation attempts against non-pending or internal comments
+- internal-user browser moderation flow approving a pending comment and making it visible in the normal detail page
+
 ## Deliberate limits
 
 - The integration tests replace PostgreSQL with EF Core InMemory, so they verify application behavior rather than provider-specific SQL behavior.

--- a/src/BlijvenLeren.App/Contracts/V1/LearningResourceContracts.cs
+++ b/src/BlijvenLeren.App/Contracts/V1/LearningResourceContracts.cs
@@ -13,6 +13,9 @@ public sealed record UpdateLearningResourceRequest(
 public sealed record CreateCommentRequest(
     string? Body);
 
+public sealed record ModerateCommentRequest(
+    string? Action);
+
 public sealed record LearningResourceListItemResponse(
     Guid Id,
     string Title,
@@ -38,3 +41,14 @@ public sealed record CommentResponse(
     string Status,
     DateTimeOffset CreatedUtc,
     DateTimeOffset? ModeratedUtc);
+
+public sealed record PendingCommentResponse(
+    Guid Id,
+    Guid LearningResourceId,
+    string LearningResourceTitle,
+    string AuthorDisplayName,
+    string AuthorIdentityName,
+    string AuthorType,
+    string Body,
+    string Status,
+    DateTimeOffset CreatedUtc);

--- a/src/BlijvenLeren.App/Features/Comments/CommentModerationValidator.cs
+++ b/src/BlijvenLeren.App/Features/Comments/CommentModerationValidator.cs
@@ -1,0 +1,58 @@
+using BlijvenLeren.App.Contracts.V1;
+using BlijvenLeren.App.Data.Entities;
+
+namespace BlijvenLeren.App.Features.Comments;
+
+public static class CommentModerationValidator
+{
+    public static Dictionary<string, string[]> ValidateRequest(ModerateCommentRequest request)
+    {
+        var errors = new Dictionary<string, string[]>(StringComparer.Ordinal);
+
+        if (string.IsNullOrWhiteSpace(request.Action))
+        {
+            errors["Action"] = ["Action is required."];
+            return errors;
+        }
+
+        if (!TryParseAction(request.Action, out _))
+        {
+            errors["Action"] = ["Action must be either approve or reject."];
+        }
+
+        return errors;
+    }
+
+    public static string? ValidateTransition(Comment comment)
+    {
+        if (comment.AuthorType != CommentAuthorType.External)
+        {
+            return "Only external comments can be moderated.";
+        }
+
+        if (comment.Status != CommentStatus.Pending)
+        {
+            return "Only pending comments can be moderated.";
+        }
+
+        return null;
+    }
+
+    public static bool TryParseAction(string action, out CommentStatus status)
+    {
+        if (string.Equals(action, "approve", StringComparison.OrdinalIgnoreCase))
+        {
+            status = CommentStatus.Approved;
+            return true;
+        }
+
+        if (string.Equals(action, "reject", StringComparison.OrdinalIgnoreCase))
+        {
+            status = CommentStatus.Rejected;
+            return true;
+        }
+
+        status = default;
+        return false;
+    }
+}

--- a/src/BlijvenLeren.App/Features/LearningResources/LearningResourceContractMapper.cs
+++ b/src/BlijvenLeren.App/Features/LearningResources/LearningResourceContractMapper.cs
@@ -68,4 +68,18 @@ public static class LearningResourceContractMapper
             comment.CreatedUtc,
             comment.ModeratedUtc);
     }
+
+    public static PendingCommentResponse ToPendingCommentResponse(Comment comment)
+    {
+        return new PendingCommentResponse(
+            comment.Id,
+            comment.LearningResourceId,
+            comment.LearningResource.Title,
+            comment.AuthorDisplayName,
+            comment.AuthorIdentityName,
+            comment.AuthorType.ToString(),
+            comment.Body,
+            comment.Status.ToString(),
+            comment.CreatedUtc);
+    }
 }

--- a/src/BlijvenLeren.App/Pages/Moderation/Comments.cshtml
+++ b/src/BlijvenLeren.App/Pages/Moderation/Comments.cshtml
@@ -1,0 +1,62 @@
+@page
+@model BlijvenLeren.App.Pages.Moderation.CommentsModel
+@{
+    ViewData["Title"] = "Pending comments";
+}
+
+<section class="py-4">
+    <div class="d-flex justify-content-between align-items-start gap-3 mb-4">
+        <div>
+            <h1 class="display-6 mb-2">Pending comments</h1>
+            <p class="lead mb-0">Internal moderators can approve or reject external comments from here.</p>
+        </div>
+        <span class="badge text-bg-light">Pending: @Model.PendingComments.Count</span>
+    </div>
+
+    @if (Model.PendingComments.Count == 0)
+    {
+        <div class="alert alert-info" role="alert">
+            There are no pending comments to review right now.
+        </div>
+    }
+    else
+    {
+        <div class="vstack gap-3">
+            @foreach (var comment in Model.PendingComments)
+            {
+                <article class="card">
+                    <div class="card-body">
+                        <div class="d-flex justify-content-between align-items-start gap-3 mb-2">
+                            <div>
+                                <h2 class="h5 mb-1">
+                                    <a asp-page="/LearningResources/Details" asp-route-id="@comment.LearningResourceId">
+                                        @comment.LearningResourceTitle
+                                    </a>
+                                </h2>
+                                <p class="mb-0 text-muted">
+                                    Submitted by <code>@comment.AuthorDisplayName</code>
+                                    (<code>@comment.AuthorIdentityName</code>) on
+                                    @comment.CreatedUtc.ToString("yyyy-MM-dd HH:mm")
+                                </p>
+                            </div>
+                            <span class="badge text-bg-warning">@comment.Status</span>
+                        </div>
+
+                        <p class="mb-3">@comment.Body</p>
+
+                        <div class="d-flex gap-2">
+                            <form method="post" asp-page-handler="Moderate" asp-route-id="@comment.Id">
+                                <input type="hidden" name="action" value="approve" />
+                                <button class="btn btn-success" type="submit">Approve</button>
+                            </form>
+                            <form method="post" asp-page-handler="Moderate" asp-route-id="@comment.Id">
+                                <input type="hidden" name="action" value="reject" />
+                                <button class="btn btn-outline-danger" type="submit">Reject</button>
+                            </form>
+                        </div>
+                    </div>
+                </article>
+            }
+        </div>
+    }
+</section>

--- a/src/BlijvenLeren.App/Pages/Moderation/Comments.cshtml.cs
+++ b/src/BlijvenLeren.App/Pages/Moderation/Comments.cshtml.cs
@@ -1,0 +1,72 @@
+using BlijvenLeren.App.Contracts.V1;
+using BlijvenLeren.App.Data;
+using BlijvenLeren.App.Data.Entities;
+using BlijvenLeren.App.Features.Comments;
+using BlijvenLeren.App.Features.LearningResources;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+
+namespace BlijvenLeren.App.Pages.Moderation;
+
+[Authorize(Policy = "InternalUser")]
+public sealed class CommentsModel(AppDbContext dbContext) : PageModel
+{
+    public IReadOnlyList<PendingCommentResponse> PendingComments { get; private set; } = [];
+
+    public async Task OnGetAsync(CancellationToken cancellationToken)
+    {
+        PendingComments = await LoadPendingCommentsAsync(cancellationToken);
+    }
+
+    public async Task<IActionResult> OnPostModerateAsync(Guid id, string action, CancellationToken cancellationToken)
+    {
+        var request = new ModerateCommentRequest(action);
+        var requestErrors = CommentModerationValidator.ValidateRequest(request);
+        if (requestErrors.Count > 0)
+        {
+            TempData["StatusMessage"] = requestErrors["Action"][0];
+            return RedirectToPage();
+        }
+
+        var comment = await dbContext.Comments
+            .Include(savedComment => savedComment.LearningResource)
+            .SingleOrDefaultAsync(savedComment => savedComment.Id == id, cancellationToken);
+
+        if (comment is null)
+        {
+            return NotFound();
+        }
+
+        var transitionError = CommentModerationValidator.ValidateTransition(comment);
+        if (transitionError is not null)
+        {
+            TempData["StatusMessage"] = transitionError;
+            return RedirectToPage();
+        }
+
+        CommentModerationValidator.TryParseAction(action, out var targetStatus);
+        comment.Status = targetStatus;
+        comment.ModeratedUtc = DateTimeOffset.UtcNow;
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        TempData["StatusMessage"] = targetStatus == CommentStatus.Approved
+            ? "Comment approved."
+            : "Comment rejected.";
+
+        return RedirectToPage();
+    }
+
+    private async Task<IReadOnlyList<PendingCommentResponse>> LoadPendingCommentsAsync(CancellationToken cancellationToken)
+    {
+        var comments = await dbContext.Comments
+            .AsNoTracking()
+            .Include(comment => comment.LearningResource)
+            .Where(comment => comment.AuthorType == CommentAuthorType.External && comment.Status == CommentStatus.Pending)
+            .OrderBy(comment => comment.CreatedUtc)
+            .ToListAsync(cancellationToken);
+
+        return comments.Select(LearningResourceContractMapper.ToPendingCommentResponse).ToList();
+    }
+}

--- a/src/BlijvenLeren.App/Pages/Protected.cshtml
+++ b/src/BlijvenLeren.App/Pages/Protected.cshtml
@@ -23,4 +23,5 @@
     <p>External-only route: <code>/api/auth/external</code></p>
     <p>Internal-only seed reset: <code>POST /api/demo/seed-data?reset=true</code></p>
     <p>Internal-only browser create route: <code>/LearningResources/Create</code></p>
+    <p>Internal-only moderation page: <code>/Moderation/Comments</code></p>
 </section>

--- a/src/BlijvenLeren.App/Pages/Shared/_Layout.cshtml
+++ b/src/BlijvenLeren.App/Pages/Shared/_Layout.cshtml
@@ -26,6 +26,12 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-page="/LearningResources/Index">Resources</a>
                         </li>
+                        @if (User.IsInRole("internal-user"))
+                        {
+                            <li class="nav-item">
+                                <a class="nav-link text-dark" asp-area="" asp-page="/Moderation/Comments">Moderation</a>
+                            </li>
+                        }
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-page="/Protected">Protected</a>
                         </li>

--- a/src/BlijvenLeren.App/Program.cs
+++ b/src/BlijvenLeren.App/Program.cs
@@ -308,6 +308,57 @@ app.MapPost(
     .RequireAuthorization()
     .WithSummary("Add a comment to a learning resource. Internal comments are auto-approved; external comments stay pending.");
 
+app.MapGet(
+    "/api/v1/comments/pending",
+    async (AppDbContext dbContext, CancellationToken cancellationToken) =>
+    {
+        var comments = await dbContext.Comments
+            .AsNoTracking()
+            .Include(comment => comment.LearningResource)
+            .Where(comment => comment.AuthorType == CommentAuthorType.External && comment.Status == CommentStatus.Pending)
+            .OrderBy(comment => comment.CreatedUtc)
+            .ToListAsync(cancellationToken);
+
+        return Results.Ok(comments.Select(LearningResourceContractMapper.ToPendingCommentResponse));
+    })
+    .RequireAuthorization("InternalUser")
+    .WithSummary("List pending external comments for moderation.");
+
+app.MapPost(
+    "/api/v1/comments/{id:guid}/moderation",
+    async (Guid id, ModerateCommentRequest request, AppDbContext dbContext, CancellationToken cancellationToken) =>
+    {
+        var errors = CommentModerationValidator.ValidateRequest(request);
+        if (errors.Count > 0)
+        {
+            return Results.ValidationProblem(errors);
+        }
+
+        var comment = await dbContext.Comments
+            .Include(savedComment => savedComment.LearningResource)
+            .SingleOrDefaultAsync(savedComment => savedComment.Id == id, cancellationToken);
+
+        if (comment is null)
+        {
+            return Results.NotFound();
+        }
+
+        var transitionError = CommentModerationValidator.ValidateTransition(comment);
+        if (transitionError is not null)
+        {
+            return Results.Conflict(new { error = transitionError });
+        }
+
+        CommentModerationValidator.TryParseAction(request.Action!, out var targetStatus);
+        comment.Status = targetStatus;
+        comment.ModeratedUtc = DateTimeOffset.UtcNow;
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Results.Ok(LearningResourceContractMapper.ToCommentResponse(comment));
+    })
+    .RequireAuthorization("InternalUser")
+    .WithSummary("Approve or reject a pending external comment.");
+
 app.MapPut(
     "/api/v1/learning-resources/{id:guid}",
     async (Guid id, UpdateLearningResourceRequest request, AppDbContext dbContext, CancellationToken cancellationToken) =>

--- a/test/BlijvenLeren.App.Tests/ApiResourceCrudIntegrationTests.cs
+++ b/test/BlijvenLeren.App.Tests/ApiResourceCrudIntegrationTests.cs
@@ -142,4 +142,72 @@ public sealed class ApiResourceCrudIntegrationTests : IClassFixture<TestApplicat
         Assert.NotNull(detail);
         Assert.DoesNotContain(detail.Comments, comment => comment.Body == "External comment waiting for moderation.");
     }
+
+    [Fact]
+    public async Task InternalUser_CanListAndApprovePendingExternalComments()
+    {
+        using var internalClient = _factory.CreateClient();
+        internalClient.DefaultRequestHeaders.Add("X-Test-User", "internal.demo");
+        internalClient.DefaultRequestHeaders.Add("X-Test-Roles", "internal-user");
+
+        var pendingComments = await internalClient.GetFromJsonAsync<List<PendingCommentResponse>>("/api/v1/comments/pending");
+        Assert.NotNull(pendingComments);
+        var pending = Assert.Single(pendingComments, comment => comment.Id == Guid.Parse("6b8b684d-a9d7-4b3f-8ebf-12d6736103f4"));
+
+        var moderateResponse = await internalClient.PostAsJsonAsync(
+            $"/api/v1/comments/{pending.Id}/moderation",
+            new ModerateCommentRequest("approve"));
+
+        Assert.Equal(HttpStatusCode.OK, moderateResponse.StatusCode);
+        var moderated = await moderateResponse.Content.ReadFromJsonAsync<CommentResponse>();
+        Assert.NotNull(moderated);
+        Assert.Equal("Approved", moderated.Status);
+
+        var detail = await internalClient.GetFromJsonAsync<LearningResourceDetailResponse>(
+            "/api/v1/learning-resources/f116d693-f390-45ec-8d0b-23f6784d65b4");
+        Assert.NotNull(detail);
+        Assert.Contains(detail.Comments, comment => comment.Body == "Could be useful when the UI grows beyond simple forms.");
+    }
+
+    [Fact]
+    public async Task InternalUser_CanRejectPendingExternalComment()
+    {
+        using var internalClient = _factory.CreateClient();
+        internalClient.DefaultRequestHeaders.Add("X-Test-User", "internal.demo");
+        internalClient.DefaultRequestHeaders.Add("X-Test-Roles", "internal-user");
+
+        var moderateResponse = await internalClient.PostAsJsonAsync(
+            "/api/v1/comments/6b8b684d-a9d7-4b3f-8ebf-12d6736103f4/moderation",
+            new ModerateCommentRequest("reject"));
+
+        Assert.Equal(HttpStatusCode.OK, moderateResponse.StatusCode);
+        var moderated = await moderateResponse.Content.ReadFromJsonAsync<CommentResponse>();
+        Assert.NotNull(moderated);
+        Assert.Equal("Rejected", moderated.Status);
+
+        var detail = await internalClient.GetFromJsonAsync<LearningResourceDetailResponse>(
+            "/api/v1/learning-resources/f116d693-f390-45ec-8d0b-23f6784d65b4");
+        Assert.NotNull(detail);
+        Assert.DoesNotContain(detail.Comments, comment => comment.Body == "Could be useful when the UI grows beyond simple forms.");
+    }
+
+    [Fact]
+    public async Task Moderation_RejectsInvalidStateTransitions()
+    {
+        using var internalClient = _factory.CreateClient();
+        internalClient.DefaultRequestHeaders.Add("X-Test-User", "internal.demo");
+        internalClient.DefaultRequestHeaders.Add("X-Test-Roles", "internal-user");
+
+        var internalComment = await internalClient.PostAsJsonAsync(
+            "/api/v1/learning-resources/901a31cc-3ec7-4e8b-93cb-9cb6c49054af/comments",
+            new CreateCommentRequest("Internal comment that should not be moderated."));
+        var created = await internalComment.Content.ReadFromJsonAsync<CommentResponse>();
+        Assert.NotNull(created);
+
+        var moderateResponse = await internalClient.PostAsJsonAsync(
+            $"/api/v1/comments/{created.Id}/moderation",
+            new ModerateCommentRequest("reject"));
+
+        Assert.Equal(HttpStatusCode.Conflict, moderateResponse.StatusCode);
+    }
 }

--- a/test/BlijvenLeren.App.Tests/BrowserResourceCrudIntegrationTests.cs
+++ b/test/BlijvenLeren.App.Tests/BrowserResourceCrudIntegrationTests.cs
@@ -152,6 +152,37 @@ public sealed partial class BrowserResourceCrudIntegrationTests : IClassFixture<
         Assert.DoesNotContain("External browser comment", html);
     }
 
+    [Fact]
+    public async Task InternalUser_CanApprovePendingCommentThroughBrowserModerationPage()
+    {
+        using var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+        client.DefaultRequestHeaders.Add("X-Test-User", "internal.demo");
+        client.DefaultRequestHeaders.Add("X-Test-Roles", "internal-user");
+
+        var moderationGet = await client.GetAsync("/Moderation/Comments");
+        var moderationHtml = await moderationGet.Content.ReadAsStringAsync();
+        Assert.Contains("Could be useful when the UI grows beyond simple forms.", moderationHtml);
+
+        var token = await ExtractRequestVerificationTokenAsync(moderationGet);
+        var approveResponse = await client.PostAsync(
+            "/Moderation/Comments?handler=Moderate&id=6b8b684d-a9d7-4b3f-8ebf-12d6736103f4",
+            BuildFormContent(
+                token,
+                new Dictionary<string, string>
+                {
+                    ["action"] = "approve"
+                }));
+
+        Assert.Equal(HttpStatusCode.Redirect, approveResponse.StatusCode);
+
+        var detailsResponse = await client.GetAsync("/LearningResources/Details/f116d693-f390-45ec-8d0b-23f6784d65b4");
+        var detailsHtml = await detailsResponse.Content.ReadAsStringAsync();
+        Assert.Contains("Could be useful when the UI grows beyond simple forms.", detailsHtml);
+    }
+
     private static FormUrlEncodedContent BuildFormContent(string requestVerificationToken, Dictionary<string, string> fields)
     {
         var formFields = new Dictionary<string, string>(fields)


### PR DESCRIPTION
## Summary
- add internal-only pending comment review and approve/reject moderation flows to the API and browser UI
- enforce server-side transition rules so only pending external comments can be moderated
- update tests, docs, and the auth sequence diagram for the moderation lifecycle

Fixes #11