### PR TITLE
Formalize MVP test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,25 @@ You can also build the current solution with:
 dotnet build BlijvenLeren.sln
 ```
 
+### Run tests
+
+Run the full automated suite:
+
+```bash
+dotnet test BlijvenLeren.sln -c Release
+```
+
+Run the browser smoke path only:
+
+```bash
+dotnet test test/BlijvenLeren.App.Tests/BlijvenLeren.App.Tests.csproj -c Release --filter FullyQualifiedName~BrowserSmoke
+```
+
+Current scope:
+- unit tests cover request validation and contract-mapping rules
+- integration tests cover the main API and Razor Pages flows against an in-memory app host
+- the browser smoke path verifies the main list-to-details Razor Pages journey without adding a separate browser-automation stack
+
 ### Run the container runtime
 
 ```bash
@@ -156,6 +175,11 @@ Issue `#11` adds the moderation workflow:
 - pending external comments can be approved or rejected with server-side transition rules
 - approved external comments become visible in the normal resource detail views
 - rejected external comments remain hidden from the normal resource detail views
+
+Issue `#12` formalizes the MVP automated test suite:
+- one test project now covers validation, mapping, API integration, and browser-facing Razor Pages checks
+- the suite includes an explicit `BrowserSmoke` path for the main list-to-details journey
+- README and testing docs now describe the reproducible local test commands
 
 ### Database migration workflow
 

--- a/docs/technical-decisions.md
+++ b/docs/technical-decisions.md
@@ -265,3 +265,21 @@ Issue `#11` requires review and moderation flows, but the MVP still needs a simp
 - Allow moderation from multiple ad hoc pages first: rejected because it spreads security-sensitive state transitions across the UI too early.
 
 ---
+
+## TD-018 Keep the MVP automated suite in one test project and treat browser checks as smoke tests
+**Decision**
+Keep the current automated suite in the existing test project and use HTTP-driven Razor Pages checks for the browser smoke path instead of adding a separate UI automation stack.
+
+**Why**
+Issue `#12` asks for reliable automated checks without overbuilding infrastructure. The repo already has meaningful unit and integration coverage, and the current UI is still simple server-rendered pages. Adding a second browser-specific toolchain now would overlap with that coverage more than it would increase confidence.
+
+**Impact**
+- `dotnet test BlijvenLeren.sln -c Release` stays the single reproducible test command.
+- The suite still covers browser-facing flows, but with pragmatic in-process hosting rather than heavyweight browser automation.
+- A later move to dedicated UI automation remains available if the frontend becomes more interactive.
+
+**Rejected alternatives**
+- Add Playwright immediately for the MVP smoke path: rejected because it adds setup and maintenance overhead without enough extra signal at the current UI complexity.
+- Split unit, integration, and browser checks into multiple test projects now: rejected because the current test volume does not justify the extra project structure.
+
+---

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -7,6 +7,8 @@ The MVP currently uses automated tests at two levels:
 - focused unit tests for learning-resource contract mapping and request validation
 - integration tests for the first CRUD vertical slice across both API and browser routes
 
+Issue `#12` keeps that structure intentionally small rather than introducing a separate browser-automation stack.
+
 ## Test stack
 
 - `xUnit` for the test runner
@@ -39,10 +41,16 @@ Issue `#11` coverage:
 - invalid moderation attempts against non-pending or internal comments
 - internal-user browser moderation flow approving a pending comment and making it visible in the normal detail page
 
+Issue `#12` suite formalization:
+- the `BrowserSmoke` test trait marks the smallest review-friendly end-to-end Razor Pages path
+- `dotnet test BlijvenLeren.sln -c Release` runs the full suite reproducibly
+- `dotnet test test/BlijvenLeren.App.Tests/BlijvenLeren.App.Tests.csproj -c Release --filter FullyQualifiedName~BrowserSmoke` runs only the smoke path
+
 ## Deliberate limits
 
 - The integration tests replace PostgreSQL with EF Core InMemory, so they verify application behavior rather than provider-specific SQL behavior.
 - The browser coverage is server-rendered Razor Pages exercised through HTTP, not full browser automation.
+- This repo intentionally does not add a second UI-test framework yet because the current UI is still simple server-rendered pages and the assignment favors pragmatic scope.
 - The OIDC login redirect against local Keycloak is not part of the automated suite yet; it is still verified manually in the compose runtime.
 
 ## Follow-up direction

--- a/test/BlijvenLeren.App.Tests/BrowserResourceCrudIntegrationTests.cs
+++ b/test/BlijvenLeren.App.Tests/BrowserResourceCrudIntegrationTests.cs
@@ -16,16 +16,22 @@ public sealed partial class BrowserResourceCrudIntegrationTests : IClassFixture<
     }
 
     [Fact]
-    public async Task ListingPage_RendersSeededResources()
+    [Trait("Category", "BrowserSmoke")]
+    public async Task BrowserSmoke_List_To_Details_Path_RendersSeededContent()
     {
         using var client = _factory.CreateClient();
 
-        var response = await client.GetAsync("/LearningResources");
-        var html = await response.Content.ReadAsStringAsync();
+        var listResponse = await client.GetAsync("/LearningResources");
+        var listHtml = await listResponse.Content.ReadAsStringAsync();
+        var detailsResponse = await client.GetAsync("/LearningResources/Details/901a31cc-3ec7-4e8b-93cb-9cb6c49054af");
+        var detailsHtml = await detailsResponse.Content.ReadAsStringAsync();
 
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.Contains("API Design Basics", html);
-        Assert.Contains("Browser Accessibility Checklist", html);
+        Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, detailsResponse.StatusCode);
+        Assert.Contains("API Design Basics", listHtml);
+        Assert.Contains("Browser Accessibility Checklist", listHtml);
+        Assert.Contains("API Design Basics", detailsHtml);
+        Assert.Contains("Good primer for the API-first part of the demo.", detailsHtml);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- keep the current suite in one test project instead of adding overlapping test infrastructure
- mark and document the browser smoke path alongside the existing unit and integration coverage
- document the reproducible full-suite and smoke-only test commands

Fixes #12