### PR TITLE
Improve documentation traceability

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ The original brief is intentionally open-ended and expects pragmatic choices rat
 - a local, containerized setup for application, database and identity provider
 - diagrams that explain the architecture and authentication model
 
+## Review guide
+
+If you want the fastest walkthrough of what is built versus deferred, start here:
+- [Functional requirements](docs/functional-requirements.md) for requirement-to-implementation traceability
+- [Architecture](docs/architecture.md) for the current runtime, auth, and moderation design
+- [Testing strategy](docs/testing-strategy.md) for what is covered automatically and what is still manual
+- [Security](docs/security.md) for demo shortcuts and active safeguards
+- [Backlog](docs/backlog.md) for intentionally deferred work and its impact
+
 ## What is included
 
 - .NET application code
@@ -180,6 +189,17 @@ Issue `#12` formalizes the MVP automated test suite:
 - one test project now covers validation, mapping, API integration, and browser-facing Razor Pages checks
 - the suite includes an explicit `BrowserSmoke` path for the main list-to-details journey
 - README and testing docs now describe the reproducible local test commands
+
+## Traceability summary
+
+Current implemented requirement coverage:
+- FR-01 through FR-11 are implemented in the current MVP slice
+- FR-12 and FR-13 are implemented as an MVP subset rather than a fully polished product surface
+
+Current notable deferrals:
+- interactive API docs are tracked in issue `#20`
+- browser/API list ergonomics such as pagination, filtering, and sorting remain deferred
+- production hardening, richer moderation auditability, and cloud/IaC concerns remain intentionally out of MVP scope
 
 ### Database migration workflow
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -200,6 +200,8 @@ Impact:
 
 ## Diagrams
 
+The Mermaid diagrams are intended to stay aligned with the implementation and this document.
+
 See:
 - `../diagrams/context.mmd`
 - `../diagrams/container.mmd`

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,55 +1,83 @@
 # Backlog
 
+This file captures work that is intentionally deferred, not forgotten.
+
+Reading guide:
+- each section groups deferred work by the issue that made the trade-off
+- items stay here only if they still matter after later issues land
+- the impact line explains what reviewers should assume is missing today
+
 ## Deferred from issue #4
 
 - Split browser UI and API into separate projects if later scope, hosting or team boundaries justify it.
 - Add a shared contracts project if DTO reuse starts to create coupling or duplication.
 - Add coding standards enforcement such as `.editorconfig` and CI validation once the codebase has more than the initial bootstrap slice.
-- Add automated tests as part of issue `#12`, which already tracks the MVP test suite.
+Impact:
+The current repo favors one combined app and lightweight project structure over earlier separation.
 
 ## Deferred from issue #5
 
 - Add Docker Compose profiles for a faster inner-loop setup once more services exist.
 - Add explicit healthchecks and readiness ordering for all services instead of relying on startup timing.
 - Replace the Keycloak development-mode defaults with stronger local configuration once the authentication flow is implemented.
+Impact:
+The local runtime is reproducible, but not yet optimized or hardened.
 
 ## Deferred from issue #6
 
-- Add seed data for a richer local demo once the CRUD flow exists.
 - Add more targeted indexes after the real list and moderation query patterns are implemented.
-- Split the persistence smoke path into automated integration tests once issue `#12` is implemented.
+Impact:
+Persistence is reviewable and tested at the app level, but database tuning is still minimal.
 
 ## Deferred from issue #18
 
 - Add environment-specific seed sets once reviewer and developer workflows diverge.
 - Add richer personas, more comments per resource, and moderation-history examples once the UI can surface them.
 - Replace the HTTP reseed endpoint with a more role-aware or operator-only flow once authentication and authorization are implemented.
+Impact:
+The demo data is predictable and useful, but still optimized for one shared MVP walkthrough.
 
 ## Deferred from issue #7
 
 - Tighten token validation and cookie settings for production-like environments.
 - Move committed demo credentials and realm provisioning out of the default runtime for non-demo environments.
 - Add built-in OpenAPI generation and a local interactive API docs UI in issue `#20`.
+Impact:
+Authentication is suitable for local review, not for production deployment.
 
 ## Deferred from issue #8
 
-- Add update/delete contracts and handlers once the internal CRUD workflow is implemented.
 - Add explicit API versioning strategy documentation once there is more than one versioned slice.
 - Revisit whether the current EF-entity-as-domain baseline should be split further once business rules become richer.
+Impact:
+The current API boundary is deliberate, but not yet a broader long-term versioning strategy.
 
 ## Deferred from issue #9
 
 - Add pagination, filtering, and sorting to the resource list in browser and API views.
 - Add optimistic concurrency handling for concurrent edits and deletes.
 - Add browser automation if the UI grows beyond the current server-rendered forms and navigation.
+Impact:
+CRUD behavior exists, but list ergonomics and conflict handling are still MVP-level.
 
 ## Deferred from issue #10
 
 - Add edit and delete behavior for comments once comment ownership UX is defined.
 - Add anti-spam or rate-limit controls for comment submission.
+Impact:
+Comment submission works, but community-facing resilience and management features remain light.
 
 ## Deferred from issue #11
 
 - Add moderation audit history beyond the current status and timestamp fields.
 - Add bulk approval or rejection operations if the queue grows.
 - Add richer moderator context such as linked resource excerpts or filters once the queue becomes larger.
+Impact:
+Moderation decisions are enforceable, but not yet optimized for higher-volume reviewer workflows.
+
+## Deferred from issue #12
+
+- Add CI workflow or GitHub PR checks for automatic execution outside local development.
+- Add more failure-path coverage if business rules become more complex.
+Impact:
+The automated suite is reproducible locally, but not yet enforced in hosted automation.

--- a/docs/functional-requirements.md
+++ b/docs/functional-requirements.md
@@ -87,6 +87,24 @@ The main functionality shall be accessible through a browser-based application.
 - FR-12 is partially implemented through the health/auth/resource API slice.
 - FR-13 is partially implemented through the current Razor Pages landing, protected, and learning-resource CRUD pages.
 
+## Traceability matrix
+
+| Requirement | Status | Current implementation | Deferred notes |
+| --- | --- | --- | --- |
+| FR-01 List learning resources | Implemented | `GET /api/v1/learning-resources`, `/LearningResources` | Pagination/filtering/sorting are deferred. |
+| FR-02 View learning resource details | Implemented | `GET /api/v1/learning-resources/{id}`, `/LearningResources/Details/{id}` | Detail view stays intentionally simple. |
+| FR-03 Add learning resource | Implemented | `POST /api/v1/learning-resources`, `/LearningResources/Create` | Internal-user only in the MVP. |
+| FR-04 Edit learning resource | Implemented | `PUT /api/v1/learning-resources/{id}`, `/LearningResources/Edit/{id}` | No concurrency protection yet. |
+| FR-05 Delete learning resource | Implemented | `DELETE /api/v1/learning-resources/{id}`, delete action on `/LearningResources/Details/{id}` | No soft-delete or recovery flow. |
+| FR-06 Add comment to learning resource | Implemented | `POST /api/v1/learning-resources/{id}/comments`, browser comment form on details page | No comment edit/delete flow yet. |
+| FR-07 Auto-publish internal comments | Implemented | Internal comments are stored as `Approved` immediately | Current behavior is role-driven on the server. |
+| FR-08 Moderate external comments | Implemented | External comments start as `Pending` and stay hidden until approved | Moderation audit history is deferred. |
+| FR-09 Review pending comments | Implemented | `GET /api/v1/comments/pending`, `/Moderation/Comments` | Queue filtering and richer review context are deferred. |
+| FR-10 Approve or reject pending comments | Implemented | `POST /api/v1/comments/{id}/moderation`, browser approve/reject actions | Bulk moderation is deferred. |
+| FR-11 Authentication | Implemented | Local Keycloak OIDC login and bearer validation | Social login remains a future extension. |
+| FR-12 API access | Partially implemented | Health/auth/resource/comment/moderation endpoints | Interactive API docs and broader API completeness are deferred. |
+| FR-13 Browser access | Partially implemented | Razor Pages landing, protected area, CRUD pages, moderation page | UI polish and broader flows remain deferred. |
+
 ## Notes and implementation choices
 
 The brief mentions social login as a preference rather than an absolute requirement.  

--- a/docs/security.md
+++ b/docs/security.md
@@ -36,3 +36,9 @@ This MVP uses a local Keycloak instance to demonstrate authentication and role-b
 
 - Enforce stronger cookie settings and production-grade HTTPS-only behavior.
 - Move test account provisioning out of committed realm-import data for non-demo environments.
+
+## Review traceability
+
+- Authentication and authorization requirements are mapped in `docs/functional-requirements.md`.
+- Current protected boundaries are listed in `docs/architecture.md`.
+- Deferred hardening work is tracked in `docs/backlog.md`.

--- a/docs/technical-decisions.md
+++ b/docs/technical-decisions.md
@@ -283,3 +283,21 @@ Issue `#12` asks for reliable automated checks without overbuilding infrastructu
 - Split unit, integration, and browser checks into multiple test projects now: rejected because the current test volume does not justify the extra project structure.
 
 ---
+
+## TD-019 Make requirement traceability explicit in the repo docs
+**Decision**
+Keep requirement coverage, deferred work, and review guidance explicit across the README and the dedicated docs instead of relying on reviewers to infer status from code or PR history alone.
+
+**Why**
+Issue `#13` exists because this repository is part of an interview assignment, not just a code drop. Reviewers need a fast way to see what is built, what is partial, what is deferred, and why those trade-offs were made.
+
+**Impact**
+- `docs/functional-requirements.md` now acts as the primary requirement traceability document.
+- `docs/backlog.md` stays focused on still-relevant deferred work plus its impact.
+- The README can be used as a guided entry point rather than only as a runbook.
+
+**Rejected alternatives**
+- Keep the rationale only in PRs and commit history: rejected because it makes repository review slower and less durable.
+- Add a separate ADR system now: rejected because the current repo size does not yet justify another documentation framework.
+
+---

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -58,3 +58,9 @@ Issue `#12` suite formalization:
 - Add provider-realistic persistence tests if query complexity increases.
 - Add browser automation if the UI becomes more interactive than basic Razor Pages forms.
 - Add compose-level smoke checks once CI/runtime setup becomes part of the assignment scope.
+
+## Review traceability
+
+- Requirement coverage lives in `docs/functional-requirements.md`.
+- Security-sensitive behavior under test is summarized in `docs/security.md`.
+- Remaining testing gaps are tracked in `docs/backlog.md`.


### PR DESCRIPTION
## Summary
- add clearer review guidance and requirement traceability across the README and docs
- clean up the backlog so it only keeps still-relevant deferred work with impact notes
- document why explicit repo-level traceability is a deliberate choice for this assignment

Fixes #13