### PR TITLE
Add built-in OpenAPI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Useful endpoints after startup:
 - app landing page: `http://localhost:8080/`
 - app health: `http://localhost:8080/api/health`
 - dependency probe: `http://localhost:8080/api/health/dependencies`
+- OpenAPI document: `http://localhost:8080/openapi/v1.json`
+- API docs UI: `http://localhost:8080/docs`
 - browser resource list: `http://localhost:8080/LearningResources`
 - browser resource details: `http://localhost:8080/LearningResources/{id}`
 - browser resource create route: `http://localhost:8080/LearningResources/Create`
@@ -190,6 +192,12 @@ Issue `#12` formalizes the MVP automated test suite:
 - the suite includes an explicit `BrowserSmoke` path for the main list-to-details journey
 - README and testing docs now describe the reproducible local test commands
 
+Issue `#20` adds local API docs:
+- the app now generates a built-in ASP.NET Core OpenAPI document at `/openapi/v1.json`
+- Scalar serves a separate interactive docs UI at `/docs`
+- protected API endpoints are annotated with bearer-token requirements and `401`/`403` response metadata
+- the local docs flow uses the same bearer tokens already documented for API testing
+
 ## Traceability summary
 
 Current implemented requirement coverage:
@@ -253,8 +261,9 @@ curl "http://localhost:8080/api/auth/me" -H "Authorization: Bearer <access_token
 ```
 
 API docs note:
-- interactive API docs are deferred to follow-up issue `#20`
-- for now, use the documented curl examples or your preferred HTTP client against the local endpoints
+- the built-in OpenAPI document is available at `http://localhost:8080/openapi/v1.json`
+- the interactive local docs UI is available at `http://localhost:8080/docs`
+- for protected endpoints, first obtain a bearer token from the local Keycloak realm, then use the docs UI auth panel or your preferred HTTP client
 
 Learning-resource create example:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,6 +36,7 @@ Current runtime behavior:
 - `app` can reach `db` through the compose network name `db`
 - `app` can reach `idp` through the compose network name `idp`
 - `app` exposes `/api/health/dependencies` to show whether those dependencies are reachable from inside the runtime
+- `app` exposes `/openapi/v1.json` for the generated API document and `/docs` for the local interactive docs UI
 - `app` applies pending EF Core migrations automatically in the compose runtime before serving requests
 - `app` seeds demo data automatically in the compose runtime when the database is empty
 - `idp` imports the local demo realm, roles, and test users on startup
@@ -74,6 +75,12 @@ Current moderation behavior:
 - moderation actions go through `POST /api/v1/comments/{id}/moderation` or the browser approve/reject forms
 - only pending external comments can transition to `Approved` or `Rejected`
 - moderation timestamps are recorded when an internal user makes the decision
+
+Current API docs behavior:
+- the built-in ASP.NET Core OpenAPI stack generates a local `v1` document
+- the document is filtered to `/api/*` paths so browser-login endpoints do not clutter the API review surface
+- Scalar provides the local interactive docs UI without becoming a long-term API-stack decision by itself
+- protected endpoints include explicit bearer-token guidance plus `401` and `403` response metadata
 
 ## Data layer
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -41,9 +41,16 @@ The demo data is predictable and useful, but still optimized for one shared MVP 
 
 - Tighten token validation and cookie settings for production-like environments.
 - Move committed demo credentials and realm provisioning out of the default runtime for non-demo environments.
-- Add built-in OpenAPI generation and a local interactive API docs UI in issue `#20`.
 Impact:
 Authentication is suitable for local review, not for production deployment.
+
+## Deferred from issue #20
+
+- Add richer endpoint descriptions, examples, and tags as the API surface grows.
+- Add environment-specific exposure rules so API docs are not automatically available outside local review environments.
+- Revisit grouping and tagging once the API expands beyond the current MVP slices.
+Impact:
+The docs surface is now useful for local review, but still intentionally lightweight and local-first.
 
 ## Deferred from issue #8
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -31,6 +31,13 @@ This MVP uses a local Keycloak instance to demonstrate authentication and role-b
 - External comments are stored as pending instead of being published immediately in the normal resource views.
 - Pending-comment review and moderation actions are restricted to the `internal-user` role.
 - Server-side moderation rules reject attempts to moderate internal comments or already-moderated comments.
+- The local docs UI only documents bearer-token use for protected API endpoints; it does not bypass the app's normal authorization checks.
+
+## API docs auth behavior
+
+- `/openapi/v1.json` and `/docs` are local review aids, not separate auth surfaces.
+- Protected endpoints in the generated document are annotated with bearer-token guidance and `401` / `403` responses.
+- For local review, obtain a bearer token from the demo Keycloak realm and use that token in the docs UI when calling protected endpoints.
 
 ## Deferred hardening
 

--- a/docs/technical-decisions.md
+++ b/docs/technical-decisions.md
@@ -301,3 +301,21 @@ Issue `#13` exists because this repository is part of an interview assignment, n
 - Add a separate ADR system now: rejected because the current repo size does not yet justify another documentation framework.
 
 ---
+
+## TD-020 Use the built-in ASP.NET Core OpenAPI stack plus a separate local docs UI
+**Decision**
+Generate the OpenAPI document with `Microsoft.AspNetCore.OpenApi` and expose the local interactive review surface through Scalar.
+
+**Why**
+Issue `#20` asks for a platform-aligned API docs setup after the authentication work settled. The built-in OpenAPI stack keeps the document generation close to ASP.NET Core itself, while a separate UI keeps the interactive layer replaceable.
+
+**Impact**
+- `/openapi/v1.json` is now a first-class local artifact for review and tooling.
+- `/docs` provides an interactive local reference without reintroducing the earlier Swagger-specific flow confusion.
+- Protected endpoints stay clearly documented through bearer-token descriptions and auth-related response metadata.
+
+**Rejected alternatives**
+- Reintroduce Swashbuckle: rejected because the repo already chose to avoid treating it as the long-term docs path.
+- Add a custom docs page instead of a standard UI: rejected because it would add maintenance without improving review value.
+
+---

--- a/src/BlijvenLeren.App/BlijvenLeren.App.csproj
+++ b/src/BlijvenLeren.App/BlijvenLeren.App.csproj
@@ -9,11 +9,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.10.3" />
   </ItemGroup>
 
 </Project>

--- a/src/BlijvenLeren.App/OpenApi/OpenApiDocumentConfiguration.cs
+++ b/src/BlijvenLeren.App/OpenApi/OpenApiDocumentConfiguration.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+
+namespace BlijvenLeren.App.OpenApi;
+
+public static class OpenApiDocumentConfiguration
+{
+    public const string BearerSchemeName = "BearerAuth";
+
+    public static void Configure(OpenApiOptions options)
+    {
+        options.AddDocumentTransformer((document, _, _) =>
+        {
+            document.Info = new OpenApiInfo
+            {
+                Title = "BlijvenLeren API",
+                Version = "v1",
+                Description = "Local MVP API surface for review. Use a bearer token from the local Keycloak realm for protected endpoints."
+            };
+
+            var apiPaths = new OpenApiPaths();
+            foreach (var path in document.Paths.Where(path => path.Key.StartsWith("/api", StringComparison.OrdinalIgnoreCase)))
+            {
+                apiPaths.Add(path.Key, path.Value);
+            }
+
+            document.Paths = apiPaths;
+            document.Components ??= new OpenApiComponents();
+            document.Components.SecuritySchemes = new Dictionary<string, IOpenApiSecurityScheme>
+            {
+                [BearerSchemeName] = new OpenApiSecurityScheme
+                {
+                    Type = SecuritySchemeType.Http,
+                    Scheme = "bearer",
+                    BearerFormat = "JWT",
+                    In = ParameterLocation.Header,
+                    Description = "Paste a bearer token from the local Keycloak realm. Protected endpoints use the internal-user or external-contributor roles."
+                }
+            };
+
+            return Task.CompletedTask;
+        });
+    }
+}

--- a/src/BlijvenLeren.App/OpenApi/OpenApiEndpointConventionBuilderExtensions.cs
+++ b/src/BlijvenLeren.App/OpenApi/OpenApiEndpointConventionBuilderExtensions.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.OpenApi;
+
+namespace BlijvenLeren.App.OpenApi;
+
+public static class OpenApiEndpointConventionBuilderExtensions
+{
+    public static TBuilder WithBearerAuthOpenApi<TBuilder>(this TBuilder builder, string? description = null)
+        where TBuilder : IEndpointConventionBuilder
+    {
+        return builder.AddOpenApiOperationTransformer((operation, _, _) =>
+        {
+            if (!string.IsNullOrWhiteSpace(description))
+            {
+                operation.Description = string.IsNullOrWhiteSpace(operation.Description)
+                    ? description
+                    : $"{operation.Description}\n\n{description}";
+            }
+
+            operation.Responses ??= new OpenApiResponses();
+            operation.Responses.TryAdd("401", new OpenApiResponse
+            {
+                Description = "Missing or invalid bearer token."
+            });
+            operation.Responses.TryAdd("403", new OpenApiResponse
+            {
+                Description = "Authenticated, but missing the required role."
+            });
+
+            return Task.CompletedTask;
+        });
+    }
+}

--- a/src/BlijvenLeren.App/Program.cs
+++ b/src/BlijvenLeren.App/Program.cs
@@ -6,6 +6,7 @@ using BlijvenLeren.App.Data;
 using BlijvenLeren.App.Data.Entities;
 using BlijvenLeren.App.Features.Comments;
 using BlijvenLeren.App.Features.LearningResources;
+using BlijvenLeren.App.OpenApi;
 using BlijvenLeren.App.Security;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
@@ -14,6 +15,7 @@ using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Extensions.Options;
+using Scalar.AspNetCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -30,6 +32,7 @@ builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("BlijvenLeren")));
 builder.Services.AddScoped<ClaimsPrincipalFactory>();
 builder.Services.AddScoped<DemoDataSeeder>();
+builder.Services.AddOpenApi(OpenApiDocumentConfiguration.Configure);
 builder.Services.AddRazorPages();
 builder.Services.AddHttpClient();
 builder.Services.AddAuthentication(options =>
@@ -167,6 +170,15 @@ app.UseRouting();
 app.UseAuthentication();
 app.UseAuthorization();
 
+app.MapOpenApi("/openapi/{documentName}.json");
+app.MapScalarApiReference(
+    "/docs",
+    options =>
+    {
+        options.Title = "BlijvenLeren API Docs";
+        options.OpenApiRoutePattern = "/openapi/{documentName}.json";
+    });
+
 app.MapGet(
     "/account/login",
     (string? returnUrl) =>
@@ -248,6 +260,7 @@ app.MapPost(
         return Results.Created($"/api/v1/learning-resources/{resource.Id}", LearningResourceContractMapper.ToDetailResponse(resource));
     })
     .RequireAuthorization("InternalUser")
+    .WithBearerAuthOpenApi("Requires an internal-user bearer token.")
     .WithSummary("Create a learning resource with MVP validation rules.");
 
 app.MapGet(
@@ -306,6 +319,7 @@ app.MapPost(
             LearningResourceContractMapper.ToCommentResponse(comment));
     })
     .RequireAuthorization()
+    .WithBearerAuthOpenApi("Requires a bearer token from the local Keycloak realm.")
     .WithSummary("Add a comment to a learning resource. Internal comments are auto-approved; external comments stay pending.");
 
 app.MapGet(
@@ -322,6 +336,7 @@ app.MapGet(
         return Results.Ok(comments.Select(LearningResourceContractMapper.ToPendingCommentResponse));
     })
     .RequireAuthorization("InternalUser")
+    .WithBearerAuthOpenApi("Requires an internal-user bearer token.")
     .WithSummary("List pending external comments for moderation.");
 
 app.MapPost(
@@ -357,6 +372,7 @@ app.MapPost(
         return Results.Ok(LearningResourceContractMapper.ToCommentResponse(comment));
     })
     .RequireAuthorization("InternalUser")
+    .WithBearerAuthOpenApi("Requires an internal-user bearer token.")
     .WithSummary("Approve or reject a pending external comment.");
 
 app.MapPut(
@@ -384,6 +400,7 @@ app.MapPut(
         return Results.Ok(LearningResourceContractMapper.ToDetailResponse(resource));
     })
     .RequireAuthorization("InternalUser")
+    .WithBearerAuthOpenApi("Requires an internal-user bearer token.")
     .WithSummary("Update a learning resource with MVP validation rules.");
 
 app.MapDelete(
@@ -404,6 +421,7 @@ app.MapDelete(
         return Results.NoContent();
     })
     .RequireAuthorization("InternalUser")
+    .WithBearerAuthOpenApi("Requires an internal-user bearer token.")
     .WithSummary("Delete a learning resource.");
 
 app.MapPost(
@@ -459,6 +477,7 @@ app.MapPost(
         return Results.Ok(result);
     })
     .RequireAuthorization("InternalUser")
+    .WithBearerAuthOpenApi("Requires an internal-user bearer token.")
     .WithSummary("Seed or reseed the demo dataset. Requires the internal-user role.");
 
 app.MapGet(
@@ -470,14 +489,17 @@ app.MapGet(
         roles = user.FindAll(ClaimTypes.Role).Select(claim => claim.Value).Distinct()
     }))
     .RequireAuthorization()
+    .WithBearerAuthOpenApi("Requires a bearer token from the local Keycloak realm.")
     .WithSummary("Return the current authenticated user and mapped roles.");
 
 app.MapGet("/api/auth/internal", () => Results.Ok(new { status = "ok", role = "internal-user" }))
     .RequireAuthorization("InternalUser")
+    .WithBearerAuthOpenApi("Requires an internal-user bearer token.")
     .WithSummary("Verify access for the internal-user role.");
 
 app.MapGet("/api/auth/external", () => Results.Ok(new { status = "ok", role = "external-contributor" }))
     .RequireAuthorization("ExternalContributor")
+    .WithBearerAuthOpenApi("Requires an external-contributor bearer token.")
     .WithSummary("Verify access for the external-contributor role.");
 
 app.MapStaticAssets();

--- a/test/BlijvenLeren.App.Tests/OpenApiIntegrationTests.cs
+++ b/test/BlijvenLeren.App.Tests/OpenApiIntegrationTests.cs
@@ -1,0 +1,53 @@
+using System.Text.Json;
+using BlijvenLeren.App.Tests.Infrastructure;
+
+namespace BlijvenLeren.App.Tests;
+
+public sealed class OpenApiIntegrationTests : IClassFixture<TestApplicationFactory>
+{
+    private readonly TestApplicationFactory _factory;
+
+    public OpenApiIntegrationTests(TestApplicationFactory factory)
+    {
+        _factory = factory;
+        _factory.ResetState();
+    }
+
+    [Fact]
+    public async Task OpenApiDocument_ExposesBearerSchemeAndProtectedOperationMetadata()
+    {
+        using var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/openapi/v1.json");
+        response.EnsureSuccessStatusCode();
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = document.RootElement;
+
+        var securitySchemes = root.GetProperty("components").GetProperty("securitySchemes");
+        Assert.True(securitySchemes.TryGetProperty("BearerAuth", out var bearerScheme));
+        Assert.Equal("http", bearerScheme.GetProperty("type").GetString());
+        Assert.Equal("bearer", bearerScheme.GetProperty("scheme").GetString());
+
+        var protectedOperation = root.GetProperty("paths")
+            .GetProperty("/api/v1/comments/pending")
+            .GetProperty("get");
+
+        Assert.Contains("Requires an internal-user bearer token.", protectedOperation.GetProperty("description").GetString());
+        Assert.True(protectedOperation.GetProperty("responses").TryGetProperty("401", out _));
+        Assert.True(protectedOperation.GetProperty("responses").TryGetProperty("403", out _));
+    }
+
+    [Fact]
+    public async Task DocsUi_RendersScalarPage()
+    {
+        using var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/docs");
+        response.EnsureSuccessStatusCode();
+        var html = await response.Content.ReadAsStringAsync();
+
+        Assert.Contains("BlijvenLeren API Docs", html);
+        Assert.Contains("scalar", html, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
## Summary
- add built-in ASP.NET Core OpenAPI generation and a local Scalar docs UI
- annotate protected API endpoints with bearer-token guidance plus auth-related response metadata
- document the local docs flow and add integration coverage for the OpenAPI document and docs UI

Fixes #20