### PR TITLE
docs: align MVP copy with current implementation (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,10 @@ dotnet run --no-launch-profile --project src/BlijvenLeren.App/BlijvenLeren.App.c
 ```
 
 Then open:
-- `http://127.0.0.1:5078/` for the placeholder browser page
-- `http://127.0.0.1:5078/api/health` for the placeholder API health endpoint
+- `http://127.0.0.1:5078/` for the MVP landing page and browser entry point
+- `http://127.0.0.1:5078/LearningResources` for the main browser learning-resource flow
+- `http://127.0.0.1:5078/api/health` for the application health endpoint
+- `http://127.0.0.1:5078/docs` for the local interactive API docs
 
 Local URL note:
 - the checked-in launch profile also uses port `5078`
@@ -129,18 +131,18 @@ Useful endpoints after startup:
 - external-only route: `GET http://localhost:8080/api/auth/external`
 - Keycloak admin console: `http://localhost:8081/` with `admin` / `admin`
 
-## Current bootstrap scope
+## Current MVP scope
 
-Issue `#4` establishes a runnable starting point rather than full feature coverage. The current implementation:
+Issue `#4` established the initial runnable starting point. The current implementation now:
 - uses one ASP.NET Core project to host both Razor Pages and minimal API endpoints
-- provides a placeholder landing page for the browser experience
-- exposes a placeholder health endpoint for API connectivity checks
-- intentionally leaves domain logic, persistence, authentication and containers for follow-up issues
+- provides a reviewer-facing landing page plus learning-resource browser flows
+- exposes health, auth, resource, comment, moderation, demo-data, and API-docs endpoints
+- keeps the combined-app structure as an MVP trade-off rather than a missing implementation step
 
-Issue `#5` adds the first container runtime around that bootstrap:
+Issue `#5` adds the local container runtime around that MVP:
 - `app` hosts both the browser UI and the API surface
-- `db` provides a PostgreSQL instance for later persistence work
-- `idp` provides a local Keycloak instance for later authentication work
+- `db` provides the PostgreSQL persistence used by the current app
+- `idp` provides the local Keycloak identity provider used by the current auth flow
 - the application exposes a dependency probe so container-network reachability is visible during review
 
 Issue `#6` adds the first persistence slice:
@@ -205,7 +207,6 @@ Current implemented requirement coverage:
 - FR-12 and FR-13 are implemented as an MVP subset rather than a fully polished product surface
 
 Current notable deferrals:
-- interactive API docs are tracked in issue `#20`
 - browser/API list ergonomics such as pagination, filtering, and sorting remain deferred
 - production hardening, richer moderation auditability, and cloud/IaC concerns remain intentionally out of MVP scope
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,14 +11,14 @@ The solution is designed as a locally runnable MVP with the following building b
 ## Primary flow
 
 1. User authenticates through the identity provider
-2. Web application calls API
-3. API validates identity and authorization
-4. API reads/writes learning resources and comments in the database
-5. Internal moderation flow controls visibility of external comments
+2. Browser requests and API calls both terminate in the same ASP.NET Core app
+3. The app validates identity and authorization based on route type and role requirements
+4. Razor Pages handlers and minimal API endpoints read/write learning resources and comments through the same DbContext
+5. Internal moderation rules control visibility of external comments
 
 ## Container view
 
-- `app`: browser-facing frontend and HTTP API hosted in one ASP.NET Core app for the bootstrap phase
+- `app`: browser-facing frontend and HTTP API hosted in one ASP.NET Core app for the current MVP
 - `db`: persistent relational database
 - `idp`: authentication and identity management
 
@@ -49,11 +49,11 @@ The runnable application code currently lives in:
 - `BlijvenLeren.sln`: top-level solution file for local build and future expansion
 - `test/BlijvenLeren.App.Tests`: unit and integration tests for the current learning-resource slice
 
-Current bootstrap behavior:
-- `/` serves a placeholder browser page
-- `/api/health` serves a placeholder API health response
+Current entry-point behavior:
+- `/` serves the current MVP landing page with auth and runtime guidance
+- `/api/health` serves a simple app-health response
 
-This keeps the startup slice small while still demonstrating both browser and API access paths.
+This keeps the runtime easy to review while still demonstrating both browser and API access paths.
 
 Current CRUD behavior:
 - `/LearningResources` lists the seeded learning resources in the browser
@@ -105,7 +105,7 @@ The current domain/API baseline intentionally keeps modeling straightforward:
 - EF Core entities remain the current domain model for the MVP
 - versioned transport contracts live separately under `Contracts/V1`
 - mapping and validation live in `Features/LearningResources`
-- the first versioned API slice covers list, detail, and create behavior for learning resources
+- the current versioned API slice covers list, detail, create, update, and delete behavior for learning resources plus comment and moderation endpoints
 
 This keeps the current layer count low while still separating persistence entities from external request/response contracts.
 

--- a/docs/functional-requirements.md
+++ b/docs/functional-requirements.md
@@ -84,7 +84,7 @@ The main functionality shall be accessible through a browser-based application.
 - FR-09 is implemented through `GET /api/v1/comments/pending` and `/Moderation/Comments` for internal users.
 - FR-10 is implemented through `POST /api/v1/comments/{id}/moderation` and the approve/reject actions on `/Moderation/Comments` for internal users.
 - FR-11 is implemented through the local Keycloak-backed browser login flow and bearer-token validation.
-- FR-12 is partially implemented through the health/auth/resource API slice.
+- FR-12 is partially implemented through the health/auth/resource/comment/moderation API slice plus local OpenAPI documentation.
 - FR-13 is partially implemented through the current Razor Pages landing, protected, and learning-resource CRUD pages.
 
 ## Traceability matrix
@@ -102,7 +102,7 @@ The main functionality shall be accessible through a browser-based application.
 | FR-09 Review pending comments | Implemented | `GET /api/v1/comments/pending`, `/Moderation/Comments` | Queue filtering and richer review context are deferred. |
 | FR-10 Approve or reject pending comments | Implemented | `POST /api/v1/comments/{id}/moderation`, browser approve/reject actions | Bulk moderation is deferred. |
 | FR-11 Authentication | Implemented | Local Keycloak OIDC login and bearer validation | Social login remains a future extension. |
-| FR-12 API access | Partially implemented | Health/auth/resource/comment/moderation endpoints | Interactive API docs and broader API completeness are deferred. |
+| FR-12 API access | Partially implemented | Health/auth/resource/comment/moderation endpoints plus `/openapi/v1.json` and `/docs` | Broader API completeness remains deferred. |
 | FR-13 Browser access | Partially implemented | Razor Pages landing, protected area, CRUD pages, moderation page | UI polish and broader flows remain deferred. |
 
 ## Notes and implementation choices

--- a/src/BlijvenLeren.App/Pages/Index.cshtml
+++ b/src/BlijvenLeren.App/Pages/Index.cshtml
@@ -5,16 +5,16 @@
 }
 
 <section class="py-4">
-    <h1 class="display-5 mb-3">BlijvenLeren MVP bootstrap</h1>
+    <h1 class="display-5 mb-3">BlijvenLeren MVP</h1>
     <p class="lead">
-        This starter app intentionally combines the browser UI and HTTP API in one ASP.NET Core project.
+        This MVP intentionally combines the browser UI and HTTP API in one ASP.NET Core project.
     </p>
     <p>
-        It provides a basic landing page for the browser experience and a placeholder API health endpoint at
-        <code>/api/health</code> so later vertical slices can build on a runnable foundation.
+        It demonstrates the main learning-resource, comment-moderation, authentication, and API-docs flows in one
+        locally runnable app.
     </p>
     <p>
-        The first browser CRUD slice now lives at <a asp-page="/LearningResources/Index"><code>/LearningResources</code></a>.
+        The main browser flow starts at <a asp-page="/LearningResources/Index"><code>/LearningResources</code></a>.
     </p>
 </section>
 

--- a/src/BlijvenLeren.App/Pages/Shared/_Layout.cshtml
+++ b/src/BlijvenLeren.App/Pages/Shared/_Layout.cshtml
@@ -58,7 +58,7 @@
 
     <footer class="border-top footer text-muted">
         <div class="container">
-            &copy; 2026 - BlijvenLeren MVP bootstrap
+            &copy; 2026 - BlijvenLeren MVP
         </div>
     </footer>
 

--- a/src/BlijvenLeren.App/Program.cs
+++ b/src/BlijvenLeren.App/Program.cs
@@ -208,7 +208,7 @@ app.MapGet("/api/health", () => Results.Ok(new
 {
     status = "ok",
     application = "BlijvenLeren",
-    mode = "bootstrap"
+    mode = "mvp"
 }))
     .WithSummary("Return a simple application health response.");
 


### PR DESCRIPTION
## Summary
This PR aligns reviewer-facing copy with the current MVP so the repo and running app describe what is actually implemented today.

## Why
Several docs and pieces of in-app copy still referred to the application as a bootstrap or placeholder state, even though the MVP now includes authentication, CRUD, moderation, demo data, and local API docs. That drift made the repository harder to review.

## Changes
- update README.md to describe the real local entry points and current MVP scope
- update docs/architecture.md to match the implemented runtime and interaction model
- update docs/functional-requirements.md to reflect the current API surface, including OpenAPI docs
- update the landing page, footer, and /api/health payload so reviewer-facing app copy no longer says ootstrap

## Verification
- dotnet build -c Release

Closes #29