### PR TITLE
feat: improve reviewer discoverability in app (#31)

### DIFF
--- a/src/BlijvenLeren.App/Pages/Index.cshtml
+++ b/src/BlijvenLeren.App/Pages/Index.cshtml
@@ -19,6 +19,46 @@
 </section>
 
 <section class="pb-4">
+    <h2 class="h4">Start Here</h2>
+    <div class="row g-3">
+        <div class="col-md-4">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h3 class="h5">Browser review</h3>
+                    <p class="mb-3">Browse seeded learning resources, inspect details, and try the comment flow.</p>
+                    <a class="btn btn-primary" asp-page="/LearningResources/Index">Open resources</a>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h3 class="h5">API review</h3>
+                    <p class="mb-3">Open the generated API docs and test protected endpoints with a bearer token.</p>
+                    <a class="btn btn-outline-primary" href="/docs">Open API docs</a>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h3 class="h5">Moderation review</h3>
+                    <p class="mb-3">Internal users can review pending external comments in the moderation queue.</p>
+                    @if (User.IsInRole("internal-user"))
+                    {
+                        <a class="btn btn-outline-primary" asp-page="/Moderation/Comments">Open moderation</a>
+                    }
+                    else
+                    {
+                        <span class="text-muted">Sign in as <code>internal.demo</code> to review moderation.</span>
+                    }
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="pb-4">
     <h2 class="h4">Authentication</h2>
     @if (User.Identity?.IsAuthenticated ?? false)
     {
@@ -50,17 +90,29 @@
 </section>
 
 <section class="pb-4">
+    <h2 class="h4">Suggested review path</h2>
+    <ol class="mb-0">
+        <li>Open <a asp-page="/LearningResources/Index"><code>/LearningResources</code></a> and inspect a seeded resource.</li>
+        <li>Sign in as <code>external.demo</code> and add a comment from a resource details page.</li>
+        <li>Sign in as <code>internal.demo</code> and open <a asp-page="/Moderation/Comments"><code>/Moderation/Comments</code></a>.</li>
+        <li>Approve the pending comment and confirm it appears on the resource details page.</li>
+        <li>Open <a href="/docs"><code>/docs</code></a> to inspect or call the protected API routes.</li>
+    </ol>
+</section>
+
+<section class="pb-4">
     <h2 class="h4">Container runtime</h2>
     <p>
         Issue <code>#5</code> adds a Docker Compose runtime with one application container plus local database and
         identity-provider services.
     </p>
     <ul>
-        <li>Application: <code>@Model.AppBaseUrl</code></li>
+        <li>Application: <a href="@Model.AppBaseUrl"><code>@Model.AppBaseUrl</code></a></li>
         <li>Database host: <code>@Model.DatabaseHost:@Model.DatabasePort</code></li>
-        <li>Identity provider: <code>@Model.IdentityProviderAuthority</code></li>
-        <li>Dependency probe: <code>@Model.AppBaseUrl/api/health/dependencies</code></li>
-        <li>Token validation route: <code>@Model.AppBaseUrl/api/auth/me</code></li>
-        <li>Browser CRUD route: <code>@Model.AppBaseUrl/LearningResources</code></li>
+        <li>Identity provider: <a href="@Model.IdentityProviderAuthority"><code>@Model.IdentityProviderAuthority</code></a></li>
+        <li>API docs: <a href="@Model.ApiDocsUrl"><code>@Model.ApiDocsUrl</code></a></li>
+        <li>Dependency probe: <a href="@Model.DependencyProbeUrl"><code>@Model.DependencyProbeUrl</code></a></li>
+        <li>Token validation route: <a href="@Model.AuthMeUrl"><code>@Model.AuthMeUrl</code></a></li>
+        <li>Browser CRUD route: <a href="@Model.LearningResourcesUrl"><code>@Model.LearningResourcesUrl</code></a></li>
     </ul>
 </section>

--- a/src/BlijvenLeren.App/Pages/Index.cshtml.cs
+++ b/src/BlijvenLeren.App/Pages/Index.cshtml.cs
@@ -16,6 +16,14 @@ public class IndexModel : PageModel
 
     public string AppBaseUrl => $"{Request.Scheme}://{Request.Host}";
 
+    public string ApiDocsUrl => $"{AppBaseUrl}/docs";
+
+    public string AuthMeUrl => $"{AppBaseUrl}/api/auth/me";
+
+    public string DependencyProbeUrl => $"{AppBaseUrl}/api/health/dependencies";
+
+    public string LearningResourcesUrl => $"{AppBaseUrl}/LearningResources";
+
     public string DatabaseHost => _runtimeOptions.Database.Host;
 
     public int DatabasePort => _runtimeOptions.Database.Port;

--- a/src/BlijvenLeren.App/Pages/Protected.cshtml
+++ b/src/BlijvenLeren.App/Pages/Protected.cshtml
@@ -16,12 +16,15 @@
         <dd class="col-sm-9"><code>@Model.RoleSummary</code></dd>
     </dl>
 
-    <p>Browser-protected route: <code>/protected</code></p>
-    <p>API token validation route: <code>/api/auth/me</code></p>
-    <p>Browser CRUD route: <code>/LearningResources</code></p>
-    <p>Internal-only route: <code>/api/auth/internal</code></p>
-    <p>External-only route: <code>/api/auth/external</code></p>
-    <p>Internal-only seed reset: <code>POST /api/demo/seed-data?reset=true</code></p>
-    <p>Internal-only browser create route: <code>/LearningResources/Create</code></p>
-    <p>Internal-only moderation page: <code>/Moderation/Comments</code></p>
+    <ul class="mb-0">
+        <li>Browser-protected route: <a asp-page="/Protected"><code>/Protected</code></a></li>
+        <li>API token validation route: <a href="/api/auth/me"><code>/api/auth/me</code></a></li>
+        <li>Browser CRUD route: <a asp-page="/LearningResources/Index"><code>/LearningResources</code></a></li>
+        <li>API docs: <a href="/docs"><code>/docs</code></a></li>
+        <li>Internal-only route: <a href="/api/auth/internal"><code>/api/auth/internal</code></a></li>
+        <li>External-only route: <a href="/api/auth/external"><code>/api/auth/external</code></a></li>
+        <li>Internal-only seed reset: <code>POST /api/demo/seed-data?reset=true</code></li>
+        <li>Internal-only browser create route: <a asp-page="/LearningResources/Create"><code>/LearningResources/Create</code></a></li>
+        <li>Internal-only moderation page: <a asp-page="/Moderation/Comments"><code>/Moderation/Comments</code></a></li>
+    </ul>
 </section>

--- a/src/BlijvenLeren.App/Pages/Shared/_Layout.cshtml
+++ b/src/BlijvenLeren.App/Pages/Shared/_Layout.cshtml
@@ -26,6 +26,9 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-page="/LearningResources/Index">Resources</a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" href="/docs">API docs</a>
+                        </li>
                         @if (User.IsInRole("internal-user"))
                         {
                             <li class="nav-item">


### PR DESCRIPTION
## Summary
This PR improves the running app as a reviewer entry point by exposing the main browser, API, and moderation paths directly in the UI.

## Why
The landing page and protected area already contained useful reviewer routes, but they were either plain text or not prominent enough. That made first-time exploration slower than necessary.

## Changes
- add a Start here section on the landing page for browser review, API review, and moderation review
- add a short suggested review path to the landing page
- make reviewer-facing runtime URLs clickable on the landing page
- add API docs to the main navigation
- turn the protected page route list into clickable links where appropriate

## Verification
- dotnet build -c Release

Closes #31