### PR TITLE
docs: add implementation traceability map (#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The original brief is intentionally open-ended and expects pragmatic choices rat
 If you want the fastest walkthrough of what is built versus deferred, start here:
 - [Reviewer walkthrough](docs/reviewer-walkthrough.md) for a short guided demo path through the MVP
 - [Functional requirements](docs/functional-requirements.md) for requirement-to-implementation traceability
+- [Traceability map](docs/traceability-map.md) for where to find the main code and tests behind each implemented slice
 - [Architecture](docs/architecture.md) for the current runtime, auth, and moderation design
 - [Testing strategy](docs/testing-strategy.md) for what is covered automatically and what is still manual
 - [Security](docs/security.md) for demo shortcuts and active safeguards

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -62,5 +62,6 @@ Issue `#12` suite formalization:
 ## Review traceability
 
 - Requirement coverage lives in `docs/functional-requirements.md`.
+- Main code and test entry points for each implemented slice live in `docs/traceability-map.md`.
 - Security-sensitive behavior under test is summarized in `docs/security.md`.
 - Remaining testing gaps are tracked in `docs/backlog.md`.

--- a/docs/traceability-map.md
+++ b/docs/traceability-map.md
@@ -1,0 +1,171 @@
+# Traceability Map
+
+This document is a compact "where to look" guide for the current MVP.
+
+Use it together with:
+- `docs/functional-requirements.md` for requirement status and scope
+- `docs/testing-strategy.md` for test intent and deliberate gaps
+- `docs/reviewer-walkthrough.md` for a short guided demo path
+
+## Learning-resource list and details
+
+Requirements:
+- `FR-01`
+- `FR-02`
+
+Primary docs:
+- `docs/functional-requirements.md`
+- `docs/architecture.md`
+
+Main code entry points:
+- `src/BlijvenLeren.App/Program.cs`
+- `src/BlijvenLeren.App/Pages/LearningResources/Index.cshtml.cs`
+- `src/BlijvenLeren.App/Pages/LearningResources/Details.cshtml.cs`
+- `src/BlijvenLeren.App/Features/LearningResources/LearningResourceContractMapper.cs`
+- `src/BlijvenLeren.App/Contracts/V1/LearningResourceContracts.cs`
+
+Main automated tests:
+- `test/BlijvenLeren.App.Tests/ApiResourceCrudIntegrationTests.cs`
+- `test/BlijvenLeren.App.Tests/BrowserResourceCrudIntegrationTests.cs`
+- `test/BlijvenLeren.App.Tests/LearningResourceContractMapperTests.cs`
+
+## Learning-resource create, edit, and delete
+
+Requirements:
+- `FR-03`
+- `FR-04`
+- `FR-05`
+
+Primary docs:
+- `docs/functional-requirements.md`
+- `docs/architecture.md`
+- `docs/security.md`
+
+Main code entry points:
+- `src/BlijvenLeren.App/Program.cs`
+- `src/BlijvenLeren.App/Pages/LearningResources/Create.cshtml.cs`
+- `src/BlijvenLeren.App/Pages/LearningResources/Edit.cshtml.cs`
+- `src/BlijvenLeren.App/Pages/LearningResources/Details.cshtml.cs`
+- `src/BlijvenLeren.App/Features/LearningResources/LearningResourceRequestValidator.cs`
+- `src/BlijvenLeren.App/Features/LearningResources/LearningResourceContractMapper.cs`
+
+Main automated tests:
+- `test/BlijvenLeren.App.Tests/ApiResourceCrudIntegrationTests.cs`
+- `test/BlijvenLeren.App.Tests/BrowserResourceCrudIntegrationTests.cs`
+- `test/BlijvenLeren.App.Tests/LearningResourceRequestValidatorTests.cs`
+
+## Comment submission and visibility rules
+
+Requirements:
+- `FR-06`
+- `FR-07`
+- `FR-08`
+
+Primary docs:
+- `docs/functional-requirements.md`
+- `docs/architecture.md`
+- `docs/security.md`
+
+Main code entry points:
+- `src/BlijvenLeren.App/Program.cs`
+- `src/BlijvenLeren.App/Pages/LearningResources/Details.cshtml.cs`
+- `src/BlijvenLeren.App/Features/Comments/CommentSubmissionFactory.cs`
+- `src/BlijvenLeren.App/Features/Comments/CommentRequestValidator.cs`
+- `src/BlijvenLeren.App/Features/LearningResources/LearningResourceContractMapper.cs`
+
+Main automated tests:
+- `test/BlijvenLeren.App.Tests/ApiResourceCrudIntegrationTests.cs`
+- `test/BlijvenLeren.App.Tests/BrowserResourceCrudIntegrationTests.cs`
+- `test/BlijvenLeren.App.Tests/CommentRequestValidatorTests.cs`
+
+## Moderation queue and approve/reject flow
+
+Requirements:
+- `FR-09`
+- `FR-10`
+
+Primary docs:
+- `docs/functional-requirements.md`
+- `docs/architecture.md`
+- `docs/security.md`
+
+Main code entry points:
+- `src/BlijvenLeren.App/Program.cs`
+- `src/BlijvenLeren.App/Pages/Moderation/Comments.cshtml.cs`
+- `src/BlijvenLeren.App/Features/Comments/CommentModerationValidator.cs`
+- `src/BlijvenLeren.App/Features/LearningResources/LearningResourceContractMapper.cs`
+
+Main automated tests:
+- `test/BlijvenLeren.App.Tests/ApiResourceCrudIntegrationTests.cs`
+- `test/BlijvenLeren.App.Tests/BrowserResourceCrudIntegrationTests.cs`
+
+## Authentication and authorization boundaries
+
+Requirement:
+- `FR-11`
+
+Primary docs:
+- `docs/functional-requirements.md`
+- `docs/architecture.md`
+- `docs/security.md`
+
+Main code entry points:
+- `src/BlijvenLeren.App/Program.cs`
+- `src/BlijvenLeren.App/Security/ClaimsPrincipalFactory.cs`
+- `src/BlijvenLeren.App/Security/AuthorityRewriteHandler.cs`
+- `src/BlijvenLeren.App/Pages/Protected.cshtml.cs`
+- `src/BlijvenLeren.App/Pages/Index.cshtml.cs`
+
+Main automated tests:
+- `test/BlijvenLeren.App.Tests/ApiResourceCrudIntegrationTests.cs`
+- `test/BlijvenLeren.App.Tests/BrowserResourceCrudIntegrationTests.cs`
+- `test/BlijvenLeren.App.Tests/Infrastructure/TestAuthHandler.cs`
+- `test/BlijvenLeren.App.Tests/Infrastructure/TestApplicationFactory.cs`
+
+## API surface and local docs
+
+Requirements:
+- `FR-12`
+
+Primary docs:
+- `docs/functional-requirements.md`
+- `docs/architecture.md`
+- `README.md`
+
+Main code entry points:
+- `src/BlijvenLeren.App/Program.cs`
+- `src/BlijvenLeren.App/OpenApi/OpenApiDocumentConfiguration.cs`
+- `src/BlijvenLeren.App/OpenApi/OpenApiEndpointConventionBuilderExtensions.cs`
+- `src/BlijvenLeren.App/Contracts/V1/LearningResourceContracts.cs`
+
+Main automated tests:
+- `test/BlijvenLeren.App.Tests/OpenApiIntegrationTests.cs`
+- `test/BlijvenLeren.App.Tests/ApiResourceCrudIntegrationTests.cs`
+
+## Browser surface and reviewer entry points
+
+Requirement:
+- `FR-13`
+
+Primary docs:
+- `docs/functional-requirements.md`
+- `docs/reviewer-walkthrough.md`
+- `README.md`
+
+Main code entry points:
+- `src/BlijvenLeren.App/Pages/Index.cshtml`
+- `src/BlijvenLeren.App/Pages/Index.cshtml.cs`
+- `src/BlijvenLeren.App/Pages/Shared/_Layout.cshtml`
+- `src/BlijvenLeren.App/Pages/LearningResources/Index.cshtml`
+- `src/BlijvenLeren.App/Pages/Protected.cshtml`
+
+Main automated tests:
+- `test/BlijvenLeren.App.Tests/BrowserResourceCrudIntegrationTests.cs`
+
+## Test infrastructure
+
+If you want the shared automated-test host setup first, start here:
+- `test/BlijvenLeren.App.Tests/Infrastructure/TestApplicationFactory.cs`
+- `test/BlijvenLeren.App.Tests/Infrastructure/TestAuthHandler.cs`
+
+These files explain how the suite boots the app, swaps authentication for controlled tests, and keeps the browser and API integration checks reproducible.


### PR DESCRIPTION
## Summary
This PR adds a lightweight traceability map so reviewers can jump from an implemented slice to the main docs, code entry points, and automated tests without hunting through the repository.

## Why
The repository already describes requirements and testing strategy, but it did not yet provide a compact where-to-look guide for the current MVP implementation.

## Changes
- add docs/traceability-map.md grouped by implemented slices and requirements
- link the new map from the README review guide
- reference the traceability map from docs/testing-strategy.md

## Verification
- dotnet build -c Release

Closes #32