### PR TITLE
ci: add hosted build and test workflow (#39)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore .NET tool manifest
+        run: dotnet tool restore
+
+      - name: Restore solution
+        run: dotnet restore BlijvenLeren.sln
+
+      - name: Build solution
+        run: dotnet build BlijvenLeren.sln -c Release --no-restore
+
+      - name: Run tests
+        run: dotnet test BlijvenLeren.sln -c Release --no-build

--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ Run the full automated suite:
 dotnet test BlijvenLeren.sln -c Release
 ```
 
+Hosted validation:
+- GitHub Actions runs the same Release build-and-test path for pull requests and pushes to `main`
+
 Run the browser smoke path only:
 
 ```bash
@@ -96,6 +99,7 @@ Current scope:
 - unit tests cover request validation and contract-mapping rules
 - integration tests cover the main API and Razor Pages flows against an in-memory app host
 - the browser smoke path verifies the main list-to-details Razor Pages journey without adding a separate browser-automation stack
+- pull requests now get a hosted GitHub Actions build-and-test check using the same main command path
 
 ### Run the container runtime
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -11,7 +11,7 @@ Reading guide:
 
 - Split browser UI and API into separate projects if later scope, hosting or team boundaries justify it.
 - Add a shared contracts project if DTO reuse starts to create coupling or duplication.
-- Add coding standards enforcement such as `.editorconfig` and CI validation once the codebase has more than the initial bootstrap slice.
+- Add coding standards enforcement such as `.editorconfig` once the codebase needs stricter style automation.
 Impact:
 The current repo favors one combined app and lightweight project structure over earlier separation.
 
@@ -84,7 +84,6 @@ Moderation decisions are enforceable, but not yet optimized for higher-volume re
 
 ## Deferred from issue #12
 
-- Add CI workflow or GitHub PR checks for automatic execution outside local development.
 - Add more failure-path coverage if business rules become more complex.
 Impact:
-The automated suite is reproducible locally, but not yet enforced in hosted automation.
+The automated suite is reproducible locally and now runs in hosted CI, but deeper negative-path coverage is still limited.

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -46,12 +46,17 @@ Issue `#12` suite formalization:
 - `dotnet test BlijvenLeren.sln -c Release` runs the full suite reproducibly
 - `dotnet test test/BlijvenLeren.App.Tests/BlijvenLeren.App.Tests.csproj -c Release --filter FullyQualifiedName~BrowserSmoke` runs only the smoke path
 
+Issue `#39` hosted validation:
+- GitHub Actions now runs the main build-and-test path on pull requests and pushes to `main`
+- the workflow restores the local tool manifest, builds the solution in `Release`, and runs `dotnet test BlijvenLeren.sln -c Release`
+
 ## Deliberate limits
 
 - The integration tests replace PostgreSQL with EF Core InMemory, so they verify application behavior rather than provider-specific SQL behavior.
 - The browser coverage is server-rendered Razor Pages exercised through HTTP, not full browser automation.
 - This repo intentionally does not add a second UI-test framework yet because the current UI is still simple server-rendered pages and the assignment favors pragmatic scope.
 - The OIDC login redirect against local Keycloak is not part of the automated suite yet; it is still verified manually in the compose runtime.
+- The hosted CI path does not yet run a compose-level smoke test.
 
 ## Follow-up direction
 


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions CI workflow so the MVP build-and-test path runs as a hosted check on pull requests and pushes to main.

## Why
The repository already documented local verification well, but reviewers still had to trust that build and test commands were run locally. This change moves the main validation path into the normal PR review flow.

## Changes
- add .github/workflows/ci.yml
- run the workflow on pull requests and pushes to main
- restore the local tool manifest, build the solution in Release, and run dotnet test BlijvenLeren.sln -c Release
- update README, testing strategy, and backlog docs to reflect the new hosted validation path

## Verification
- dotnet tool restore
- dotnet test BlijvenLeren.sln -c Release

Closes #39