### PR TITLE
fix: show reviewer-facing runtime urls on landing page (#47)

### DIFF
--- a/src/BlijvenLeren.App/Pages/Index.cshtml
+++ b/src/BlijvenLeren.App/Pages/Index.cshtml
@@ -123,8 +123,8 @@
     </p>
     <ul>
         <li>Application: <a href="@Model.AppBaseUrl"><code>@Model.AppBaseUrl</code></a></li>
-        <li>Database host: <code>@Model.DatabaseHost:@Model.DatabasePort</code></li>
-        <li>Identity provider: <a href="@Model.IdentityProviderAuthority"><code>@Model.IdentityProviderAuthority</code></a></li>
+        <li>Database host: <code>@Model.ReviewerFacingDatabaseHost</code></li>
+        <li>Identity provider: <a href="@Model.ReviewerFacingIdentityProviderAuthority"><code>@Model.ReviewerFacingIdentityProviderAuthority</code></a></li>
         <li>API docs: <a href="@Model.ApiDocsUrl"><code>@Model.ApiDocsUrl</code></a></li>
         <li>Dependency probe: <a href="@Model.DependencyProbeUrl"><code>@Model.DependencyProbeUrl</code></a></li>
         <li>Token validation route: <a href="@Model.AuthMeUrl"><code>@Model.AuthMeUrl</code></a></li>

--- a/src/BlijvenLeren.App/Pages/Index.cshtml.cs
+++ b/src/BlijvenLeren.App/Pages/Index.cshtml.cs
@@ -27,11 +27,9 @@ public class IndexModel : PageModel
 
     public string LearningResourcesUrl => $"{AppBaseUrl}/LearningResources";
 
-    public string DatabaseHost => _runtimeOptions.Database.Host;
+    public string ReviewerFacingDatabaseHost => $"{Request.Host.Host}:{_runtimeOptions.Database.Port}";
 
-    public int DatabasePort => _runtimeOptions.Database.Port;
-
-    public string IdentityProviderAuthority => _runtimeOptions.IdentityProvider.Authority;
+    public string ReviewerFacingIdentityProviderAuthority => _authOptions.Authority;
 
     public string? PreferredExternalIdentityProviderAlias { get; private set; }
 

--- a/test/BlijvenLeren.App.Tests/Infrastructure/TestApplicationFactory.cs
+++ b/test/BlijvenLeren.App.Tests/Infrastructure/TestApplicationFactory.cs
@@ -24,7 +24,10 @@ public sealed class TestApplicationFactory : WebApplicationFactory<Program>
             configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["Runtime:Database:ApplyMigrationsOnStartup"] = "false",
-                ["Runtime:Database:SeedDemoDataOnStartup"] = "false"
+                ["Runtime:Database:SeedDemoDataOnStartup"] = "false",
+                ["Runtime:Database:Host"] = "db",
+                ["Runtime:IdentityProvider:Authority"] = "http://idp:8080/realms/blijvenleren",
+                ["Authentication:Authority"] = "http://localhost:8081/realms/blijvenleren"
             });
         });
 

--- a/test/BlijvenLeren.App.Tests/LandingPageIntegrationTests.cs
+++ b/test/BlijvenLeren.App.Tests/LandingPageIntegrationTests.cs
@@ -1,0 +1,29 @@
+using BlijvenLeren.App.Tests.Infrastructure;
+
+namespace BlijvenLeren.App.Tests;
+
+public sealed class LandingPageIntegrationTests : IClassFixture<TestApplicationFactory>
+{
+    private readonly TestApplicationFactory _factory;
+
+    public LandingPageIntegrationTests(TestApplicationFactory factory)
+    {
+        _factory = factory;
+        _factory.ResetState();
+    }
+
+    [Fact]
+    public async Task LandingPage_ShowsReviewerFacingRuntimeUrls_InsteadOfInternalComposeAddresses()
+    {
+        using var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/");
+        response.EnsureSuccessStatusCode();
+        var html = await response.Content.ReadAsStringAsync();
+
+        Assert.Contains("localhost:5432", html);
+        Assert.Contains("http://localhost:8081/realms/blijvenleren", html);
+        Assert.DoesNotContain("db:5432", html);
+        Assert.DoesNotContain("http://idp:8080/realms/blijvenleren", html);
+    }
+}


### PR DESCRIPTION
## Summary
This PR fixes the landing page runtime section so it shows reviewer-facing host URLs instead of internal compose-network addresses.

## Why
The landing page was displaying internal runtime values such as db:5432 and http://idp:8080/..., which are correct inside the compose network but not useful to reviewers opening the app from the host machine.

## Changes
- show the database host on the landing page as the current host plus the configured database port
- show the identity-provider URL on the landing page using the public authentication authority rather than the internal runtime authority
- keep the internal runtime configuration intact for dependency checks and container-to-container communication
- add an integration test that simulates internal compose addresses and verifies the landing page still renders reviewer-facing URLs

## Verification
- dotnet test test/BlijvenLeren.App.Tests/BlijvenLeren.App.Tests.csproj -c Release --filter LandingPageIntegrationTests
- dotnet test BlijvenLeren.sln -c Release

Closes #47